### PR TITLE
Implement forum invite flow from forum posts

### DIFF
--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -1,3 +1,5 @@
+import 'package:booking_group_flutter/models/invite.dart';
+
 /// API Constants - Centralized configuration for all API endpoints
 class ApiConstants {
   // Base URL
@@ -25,6 +27,47 @@ class ApiConstants {
 
   static const String myGroup = '/groups/my-group';
   static String get myGroupUrl => '$baseApiUrl$myGroup';
+
+  // Invite Endpoints
+  static const String invites = '/invites';
+  static String get invitesUrl => '$baseApiUrl$invites';
+
+  static String getMyInvitesUrl({
+    InviteStatus? status,
+    int receivedPage = 1,
+    int receivedSize = 10,
+    int sentPage = 1,
+    int sentSize = 10,
+  }) {
+    final queryParameters = <String, String>{
+      'receivedPage': '$receivedPage',
+      'receivedSize': '$receivedSize',
+      'sentPage': '$sentPage',
+      'sentSize': '$sentSize',
+    };
+
+    if (status != null) {
+      queryParameters['status'] = status.name.toUpperCase();
+    }
+
+    final query = queryParameters.entries
+        .map((entry) => '${entry.key}=${entry.value}')
+        .join('&');
+
+    return '$baseApiUrl$invites/my?$query';
+  }
+
+  static String updateInviteStatusUrl(int inviteId) {
+    return '$baseApiUrl$invites/$inviteId';
+  }
+
+  // Comment Endpoints
+  static const String comments = '/comments';
+  static String get commentsUrl => '$baseApiUrl$comments';
+
+  static String getPostCommentsUrl(int postId) {
+    return '$baseApiUrl$comments/post/$postId';
+  }
 
   static String getGroupMembersUrl(int groupId) {
     return '$baseApiUrl$groups/$groupId/members';

--- a/lib/features/forum/presentation/pages/forum_page.dart
+++ b/lib/features/forum/presentation/pages/forum_page.dart
@@ -1,7 +1,9 @@
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comments_bottom_sheet.dart';
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_post_card.dart';
+import 'package:booking_group_flutter/features/groups/presentation/pages/group_detail_page.dart';
 import 'package:booking_group_flutter/models/post.dart';
 import 'package:booking_group_flutter/resources/forum_api.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 class ForumPage extends StatefulWidget {
   const ForumPage({super.key});
@@ -42,37 +44,6 @@ class _ForumPageState extends State<ForumPage> {
       setState(() {
         _isLoading = false;
       });
-    }
-  }
-
-  String _formatDate(String dateStr) {
-    try {
-      final date = DateTime.parse(dateStr);
-      return DateFormat('dd/MM/yyyy HH:mm').format(date);
-    } catch (e) {
-      return dateStr;
-    }
-  }
-
-  Color _getTypeColor(String type) {
-    switch (type.toUpperCase()) {
-      case 'FIND_GROUP':
-        return Colors.blue;
-      case 'FIND_MEMBER':
-        return Colors.green;
-      default:
-        return Colors.grey;
-    }
-  }
-
-  String _getTypeLabel(String type) {
-    switch (type.toUpperCase()) {
-      case 'FIND_GROUP':
-        return 'Tìm nhóm';
-      case 'FIND_MEMBER':
-        return 'Tìm thành viên';
-      default:
-        return type;
     }
   }
 
@@ -129,127 +100,45 @@ class _ForumPageState extends State<ForumPage> {
                     const SizedBox(height: 12),
                 itemBuilder: (context, index) {
                   final post = _posts[index];
-                  return Card(
-                    elevation: 2,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          // Header: User info and type badge
-                          Row(
-                            children: [
-                              CircleAvatar(
-                                radius: 20,
-                                backgroundImage:
-                                    post.userResponse.avatarUrl != null
-                                    ? NetworkImage(post.userResponse.avatarUrl!)
-                                    : null,
-                                child: post.userResponse.avatarUrl == null
-                                    ? Text(
-                                        post.userResponse.fullName.isNotEmpty
-                                            ? post.userResponse.fullName
-                                                  .substring(0, 1)
-                                                  .toUpperCase()
-                                            : '?',
-                                        style: const TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      )
-                                    : null,
-                              ),
-                              const SizedBox(width: 12),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      post.userResponse.fullName,
-                                      style: const TextStyle(
-                                        fontWeight: FontWeight.bold,
-                                        fontSize: 16,
-                                      ),
-                                    ),
-                                    Text(
-                                      _formatDate(post.createdAt),
-                                      style: TextStyle(
-                                        color: Colors.grey.shade600,
-                                        fontSize: 12,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 12,
-                                  vertical: 6,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: _getTypeColor(
-                                    post.type,
-                                  ).withOpacity(0.1),
-                                  borderRadius: BorderRadius.circular(20),
-                                ),
-                                child: Text(
-                                  _getTypeLabel(post.type),
-                                  style: TextStyle(
-                                    color: _getTypeColor(post.type),
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 12,
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 12),
-
-                          // Content
-                          Text(
-                            post.content,
-                            style: const TextStyle(fontSize: 14),
-                          ),
-
-                          // Group info (if exists)
-                          if (post.groupResponse != null) ...[
-                            const SizedBox(height: 12),
-                            Container(
-                              padding: const EdgeInsets.all(12),
-                              decoration: BoxDecoration(
-                                color: Colors.grey.shade100,
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              child: Row(
-                                children: [
-                                  Icon(
-                                    Icons.group,
-                                    color: Colors.grey.shade600,
-                                    size: 20,
-                                  ),
-                                  const SizedBox(width: 8),
-                                  Expanded(
-                                    child: Text(
-                                      post.groupResponse!.title,
-                                      style: TextStyle(
-                                        color: Colors.grey.shade800,
-                                        fontWeight: FontWeight.w500,
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
+                  return ForumPostCard(
+                    post: post,
+                    onViewGroup: post.groupResponse != null
+                        ? () => _openGroupDetail(post)
+                        : null,
+                    onOpenComments: () => _openComments(post),
                   );
                 },
               ),
             ),
+    );
+  }
+
+  void _openGroupDetail(Post post) {
+    final group = post.groupResponse;
+    if (group == null) return;
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => GroupDetailPage(
+          groupId: group.id,
+          groupTitle: group.title,
+        ),
+      ),
+    );
+  }
+
+  void _openComments(Post post) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (sheetContext) => ForumCommentsBottomSheet(
+        post: post,
+        parentContext: context,
+      ),
     );
   }
 }

--- a/lib/features/forum/presentation/widgets/forum_comment_input.dart
+++ b/lib/features/forum/presentation/widgets/forum_comment_input.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class ForumCommentInput extends StatelessWidget {
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final bool isSending;
+  final VoidCallback onSend;
+
+  const ForumCommentInput({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+    required this.isSending,
+    required this.onSend,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: controller,
+              focusNode: focusNode,
+              minLines: 1,
+              maxLines: 4,
+              textInputAction: TextInputAction.newline,
+              decoration: InputDecoration(
+                hintText: 'Viết bình luận...',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                isDense: true,
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          IconButton(
+            onPressed: isSending ? null : onSend,
+            icon: isSending
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.send),
+            color: const Color(0xFF8B5CF6),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/forum/presentation/widgets/forum_comment_profile_sheet.dart
+++ b/lib/features/forum/presentation/widgets/forum_comment_profile_sheet.dart
@@ -1,0 +1,154 @@
+import 'package:booking_group_flutter/models/comment.dart';
+import 'package:flutter/material.dart';
+
+class ForumCommentProfileSheet extends StatelessWidget {
+  final Comment comment;
+  final bool canInvite;
+  final bool isInviting;
+  final bool isMember;
+  final bool alreadyInvited;
+  final bool isSelf;
+  final VoidCallback? onInvite;
+
+  const ForumCommentProfileSheet({
+    super.key,
+    required this.comment,
+    required this.canInvite,
+    required this.isInviting,
+    required this.isMember,
+    required this.alreadyInvited,
+    required this.isSelf,
+    this.onInvite,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final user = comment.userResponse;
+
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Column(
+                  children: [
+                    CircleAvatar(
+                      radius: 36,
+                      backgroundImage: user.avatarUrl != null
+                          ? NetworkImage(user.avatarUrl!)
+                          : null,
+                      child: user.avatarUrl == null
+                          ? Text(
+                              user.fullName.isNotEmpty
+                                  ? user.fullName.substring(0, 1).toUpperCase()
+                                  : '?',
+                              style: const TextStyle(
+                                fontSize: 24,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            )
+                          : null,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      user.fullName,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      user.email,
+                      style: TextStyle(
+                        color: Colors.grey.shade600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 20),
+              if (user.major != null && user.major!.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.school_outlined, size: 20),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          user.major!,
+                          style: const TextStyle(fontSize: 14),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              Row(
+                children: [
+                  const Icon(Icons.badge_outlined, size: 20),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      user.studentCode.isNotEmpty
+                          ? user.studentCode
+                          : 'Chưa có mã số',
+                      style: const TextStyle(fontSize: 14),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              if (isSelf)
+                const Text(
+                  'Đây là tài khoản của bạn.',
+                  style: TextStyle(color: Colors.grey),
+                )
+              else if (alreadyInvited)
+                const Text(
+                  'Bạn đã gửi lời mời đến sinh viên này.',
+                  style: TextStyle(color: Colors.grey),
+                )
+              else if (isMember)
+                const Text(
+                  'Sinh viên này đã ở trong nhóm của bạn.',
+                  style: TextStyle(color: Colors.grey),
+                )
+              else if (!canInvite)
+                const Text(
+                  'Bạn không có quyền mời sinh viên này.',
+                  style: TextStyle(color: Colors.grey),
+                )
+              else
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: isInviting ? null : onInvite,
+                    icon: isInviting
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.person_add_alt_1_outlined),
+                    label: Text(isInviting ? 'Đang gửi...' : 'Mời vào nhóm'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFF8B5CF6),
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/forum/presentation/widgets/forum_comment_tile.dart
+++ b/lib/features/forum/presentation/widgets/forum_comment_tile.dart
@@ -1,0 +1,105 @@
+import 'package:booking_group_flutter/models/comment.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class ForumCommentTile extends StatelessWidget {
+  final Comment comment;
+  final VoidCallback onProfileTap;
+  final bool canInvite;
+  final bool isMember;
+  final bool alreadyInvited;
+
+  const ForumCommentTile({
+    super.key,
+    required this.comment,
+    required this.onProfileTap,
+    required this.canInvite,
+    required this.isMember,
+    required this.alreadyInvited,
+  });
+
+  String _formatDate(String date) {
+    try {
+      final parsed = DateTime.parse(date);
+      return DateFormat('dd/MM/yyyy HH:mm').format(parsed);
+    } catch (_) {
+      return date;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = comment.userResponse;
+
+    return ListTile(
+      leading: CircleAvatar(
+        radius: 20,
+        backgroundImage:
+            user.avatarUrl != null ? NetworkImage(user.avatarUrl!) : null,
+        child: user.avatarUrl == null
+            ? Text(
+                user.fullName.isNotEmpty
+                    ? user.fullName.substring(0, 1).toUpperCase()
+                    : '?',
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              )
+            : null,
+      ),
+      title: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  user.fullName,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (user.major != null && user.major!.isNotEmpty)
+                  Text(
+                    user.major!,
+                    style: TextStyle(
+                      color: Colors.grey.shade600,
+                      fontSize: 12,
+                    ),
+                  ),
+                const SizedBox(height: 4),
+                Text(
+                  comment.content,
+                  style: const TextStyle(fontSize: 14),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Row(
+          children: [
+            Text(
+              _formatDate(comment.createdAt),
+              style: TextStyle(color: Colors.grey.shade600, fontSize: 12),
+            ),
+            const Spacer(),
+            TextButton(
+              onPressed: onProfileTap,
+              child: Text(
+                canInvite
+                    ? alreadyInvited
+                        ? 'Đã mời'
+                        : isMember
+                            ? 'Đã trong nhóm'
+                            : 'Xem hồ sơ'
+                    : 'Xem hồ sơ',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/forum/presentation/widgets/forum_comments_bottom_sheet.dart
+++ b/lib/features/forum/presentation/widgets/forum_comments_bottom_sheet.dart
@@ -1,0 +1,354 @@
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comment_input.dart';
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comment_profile_sheet.dart';
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comment_tile.dart';
+import 'package:booking_group_flutter/models/comment.dart';
+import 'package:booking_group_flutter/models/post.dart';
+import 'package:booking_group_flutter/resources/comments_api.dart';
+import 'package:booking_group_flutter/resources/groups_api.dart';
+import 'package:booking_group_flutter/resources/invite_api.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class ForumCommentsBottomSheet extends StatefulWidget {
+  final Post post;
+  final BuildContext parentContext;
+
+  const ForumCommentsBottomSheet({
+    super.key,
+    required this.post,
+    required this.parentContext,
+  });
+
+  @override
+  State<ForumCommentsBottomSheet> createState() =>
+      _ForumCommentsBottomSheetState();
+}
+
+class _ForumCommentsBottomSheetState extends State<ForumCommentsBottomSheet> {
+  final CommentsApi _commentsApi = CommentsApi();
+  final InviteApi _inviteApi = InviteApi();
+  final GroupsApi _groupsApi = GroupsApi();
+  final TextEditingController _commentController = TextEditingController();
+  final FocusNode _commentFocusNode = FocusNode();
+
+  List<Comment> _comments = [];
+  bool _isLoading = true;
+  bool _isSendingComment = false;
+  bool _canInvite = false;
+  String? _error;
+  int? _groupId;
+  Set<int> _groupMemberIds = {};
+  Set<int> _invitedUserIds = {};
+  Map<int, bool> _inviteLoading = {};
+  String? _currentUserEmail;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentUserEmail = FirebaseAuth.instance.currentUser?.email;
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      await Future.wait([
+        _loadComments(),
+        _evaluateInvitePermission(),
+      ]);
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _loadComments() async {
+    final comments = await _commentsApi.getCommentsByPost(widget.post.id);
+    if (mounted) {
+      setState(() {
+        _comments = comments;
+      });
+    }
+  }
+
+  Future<void> _evaluateInvitePermission() async {
+    final group = widget.post.groupResponse;
+    final currentEmail = _currentUserEmail;
+
+    if (group == null || currentEmail == null) {
+      _canInvite = false;
+      return;
+    }
+
+    try {
+      final leader = await _groupsApi.getGroupLeader(group.id);
+      final leaderEmail = leader != null ? leader['email'] as String? : null;
+      final isLeader = leaderEmail != null && leaderEmail == currentEmail;
+      final isPostOwner = widget.post.userResponse.email == currentEmail;
+
+      if (isLeader || isPostOwner) {
+        final members = await _groupsApi.getGroupMembers(group.id);
+        _groupMemberIds = members.map((member) => member.id).toSet();
+        _groupId = group.id;
+        _canInvite = true;
+      } else {
+        _canInvite = false;
+      }
+    } catch (e) {
+      debugPrint('Error evaluating invite permission: $e');
+      _canInvite = false;
+    }
+  }
+
+  bool _isMember(Comment comment) {
+    return _groupMemberIds.contains(comment.userResponse.id);
+  }
+
+  bool _isInvited(Comment comment) {
+    return _invitedUserIds.contains(comment.userResponse.id);
+  }
+
+  bool _isSelf(Comment comment) {
+    return comment.userResponse.email == _currentUserEmail;
+  }
+
+  Future<void> _submitComment() async {
+    final content = _commentController.text.trim();
+    if (content.isEmpty) {
+      return;
+    }
+
+    setState(() {
+      _isSendingComment = true;
+    });
+
+    try {
+      await _commentsApi.createComment(
+        postId: widget.post.id,
+        content: content,
+      );
+
+      _commentController.clear();
+      await _loadComments();
+      _commentFocusNode.requestFocus();
+    } catch (e) {
+      ScaffoldMessenger.of(widget.parentContext).showSnackBar(
+        SnackBar(
+          content: Text(e.toString()),
+          backgroundColor: Colors.red,
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSendingComment = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleInvite(Comment comment, BuildContext sheetContext) async {
+    if (!_canInvite || _groupId == null) {
+      return;
+    }
+
+    final inviteeId = comment.userResponse.id;
+    if (inviteeId == 0 || _isMember(comment) || _isInvited(comment)) {
+      return;
+    }
+
+    setState(() {
+      _inviteLoading[inviteeId] = true;
+    });
+
+    try {
+      await _inviteApi.createInvite(
+        groupId: _groupId!,
+        inviteeId: inviteeId,
+      );
+
+      if (mounted) {
+        setState(() {
+          _invitedUserIds.add(inviteeId);
+        });
+      }
+
+      if (Navigator.of(sheetContext).canPop()) {
+        Navigator.of(sheetContext).pop();
+      }
+
+      ScaffoldMessenger.of(widget.parentContext).showSnackBar(
+        const SnackBar(
+          content: Text('Đã gửi lời mời tham gia nhóm'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(widget.parentContext).showSnackBar(
+        SnackBar(
+          content: Text(e.toString()),
+          backgroundColor: Colors.red,
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _inviteLoading.remove(inviteeId);
+        });
+      }
+    }
+  }
+
+  Future<void> _openProfile(Comment comment) async {
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (sheetContext) {
+        return ForumCommentProfileSheet(
+          comment: comment,
+          canInvite: _canInvite &&
+              !_isMember(comment) &&
+              !_isInvited(comment) &&
+              !_isSelf(comment) &&
+              widget.post.groupResponse != null,
+          isInviting: _inviteLoading[comment.userResponse.id] ?? false,
+          isMember: _isMember(comment),
+          alreadyInvited: _isInvited(comment),
+          isSelf: _isSelf(comment),
+          onInvite: _canInvite && widget.post.groupResponse != null
+              ? () => _handleInvite(comment, sheetContext)
+              : null,
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    _commentFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: FractionallySizedBox(
+        heightFactor: 0.85,
+        child: Column(
+          children: [
+            const SizedBox(height: 12),
+            Container(
+              width: 48,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade400,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  const Icon(Icons.forum_outlined),
+                  const SizedBox(width: 8),
+                  Text(
+                    'Bình luận bài viết',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const Spacer(),
+                  if (_canInvite && widget.post.groupResponse != null)
+                    const Icon(Icons.verified, color: Color(0xFF8B5CF6)),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: _isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : _error != null
+                      ? Center(
+                          child: Padding(
+                            padding: const EdgeInsets.all(24),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                const Icon(Icons.error_outline,
+                                    size: 48, color: Colors.redAccent),
+                                const SizedBox(height: 12),
+                                Text(
+                                  _error!,
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(color: Colors.redAccent),
+                                ),
+                              ],
+                            ),
+                          ),
+                        )
+                      : _comments.isEmpty
+                          ? Center(
+                              child: Padding(
+                                padding: const EdgeInsets.all(24),
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Icon(
+                                      Icons.chat_bubble_outline,
+                                      size: 48,
+                                      color: Colors.grey.shade500,
+                                    ),
+                                    const SizedBox(height: 12),
+                                    const Text('Chưa có bình luận nào.'),
+                                  ],
+                                ),
+                              ),
+                            )
+                          : ListView.separated(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 12,
+                              ),
+                              itemCount: _comments.length,
+                              separatorBuilder: (_, __) => const SizedBox(height: 8),
+                              itemBuilder: (context, index) {
+                                final comment = _comments[index];
+                                return ForumCommentTile(
+                                  comment: comment,
+                                  onProfileTap: () => _openProfile(comment),
+                                  canInvite: _canInvite &&
+                                      !_isSelf(comment) &&
+                                      widget.post.groupResponse != null,
+                                  isMember: _isMember(comment),
+                                  alreadyInvited: _isInvited(comment),
+                                );
+                              },
+                            ),
+            ),
+            const Divider(height: 1),
+            ForumCommentInput(
+              controller: _commentController,
+              focusNode: _commentFocusNode,
+              isSending: _isSendingComment,
+              onSend: _submitComment,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/forum/presentation/widgets/forum_post_card.dart
+++ b/lib/features/forum/presentation/widgets/forum_post_card.dart
@@ -1,0 +1,175 @@
+import 'package:booking_group_flutter/models/post.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class ForumPostCard extends StatelessWidget {
+  final Post post;
+  final VoidCallback? onViewGroup;
+  final VoidCallback? onOpenComments;
+
+  const ForumPostCard({
+    super.key,
+    required this.post,
+    this.onViewGroup,
+    this.onOpenComments,
+  });
+
+  Color _typeColor(String type) {
+    switch (type.toUpperCase()) {
+      case 'FIND_GROUP':
+        return Colors.blue;
+      case 'FIND_MEMBER':
+        return Colors.green;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  String _typeLabel(String type) {
+    switch (type.toUpperCase()) {
+      case 'FIND_GROUP':
+        return 'Tìm nhóm';
+      case 'FIND_MEMBER':
+        return 'Tìm thành viên';
+      default:
+        return type;
+    }
+  }
+
+  String _formatDate(String dateStr) {
+    try {
+      final date = DateTime.parse(dateStr);
+      return DateFormat('dd/MM/yyyy HH:mm').format(date);
+    } catch (_) {
+      return dateStr;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final typeColor = _typeColor(post.type);
+
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(
+                  radius: 20,
+                  backgroundImage: post.userResponse.avatarUrl != null
+                      ? NetworkImage(post.userResponse.avatarUrl!)
+                      : null,
+                  child: post.userResponse.avatarUrl == null
+                      ? Text(
+                          post.userResponse.fullName.isNotEmpty
+                              ? post.userResponse.fullName
+                                  .substring(0, 1)
+                                  .toUpperCase()
+                              : '?',
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        )
+                      : null,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        post.userResponse.fullName,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
+                      ),
+                      Text(
+                        _formatDate(post.createdAt),
+                        style: TextStyle(
+                          color: Colors.grey.shade600,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: typeColor.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Text(
+                    _typeLabel(post.type),
+                    style: TextStyle(
+                      color: typeColor,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              post.content,
+              style: const TextStyle(fontSize: 14),
+            ),
+            if (post.groupResponse != null) ...[
+              const SizedBox(height: 12),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade100,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.group,
+                      color: Colors.grey.shade600,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        post.groupResponse!.title,
+                        style: TextStyle(
+                          color: Colors.grey.shade800,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                if (onViewGroup != null)
+                  TextButton.icon(
+                    onPressed: onViewGroup,
+                    icon: const Icon(Icons.group_outlined),
+                    label: const Text('Xem nhóm'),
+                  ),
+                if (onViewGroup != null) const SizedBox(width: 12),
+                TextButton.icon(
+                  onPressed: onOpenComments,
+                  icon: const Icon(Icons.forum_outlined),
+                  label: const Text('Bình luận'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/models/comment.dart
+++ b/lib/models/comment.dart
@@ -1,0 +1,34 @@
+import 'package:booking_group_flutter/models/post.dart';
+
+class Comment {
+  final int id;
+  final int postId;
+  final UserResponse userResponse;
+  final String content;
+  final String createdAt;
+  final bool active;
+
+  Comment({
+    required this.id,
+    required this.postId,
+    required this.userResponse,
+    required this.content,
+    required this.createdAt,
+    required this.active,
+  });
+
+  factory Comment.fromJson(Map<String, dynamic> json) {
+    final postJson = json['post'] as Map<String, dynamic>?;
+
+    return Comment(
+      id: json['id'] as int? ?? 0,
+      postId: json['postId'] as int? ?? postJson?['id'] as int? ?? 0,
+      userResponse: UserResponse.fromJson(
+        json['userResponse'] as Map<String, dynamic>? ?? {},
+      ),
+      content: json['content'] as String? ?? '',
+      createdAt: json['createdAt'] as String? ?? '',
+      active: json['active'] as bool? ?? true,
+    );
+  }
+}

--- a/lib/models/invite.dart
+++ b/lib/models/invite.dart
@@ -1,0 +1,141 @@
+import 'package:booking_group_flutter/models/post.dart';
+
+enum InviteStatus { pending, accepted, declined }
+
+extension InviteStatusMapper on InviteStatus {
+  String get backendValue {
+    switch (this) {
+      case InviteStatus.pending:
+        return 'PENDING';
+      case InviteStatus.accepted:
+        return 'ACCEPTED';
+      case InviteStatus.declined:
+        return 'DECLINED';
+    }
+  }
+
+  static InviteStatus fromBackend(String? value) {
+    switch (value?.toUpperCase()) {
+      case 'ACCEPTED':
+        return InviteStatus.accepted;
+      case 'DECLINED':
+        return InviteStatus.declined;
+      case 'PENDING':
+      default:
+        return InviteStatus.pending;
+    }
+  }
+}
+
+class Invite {
+  final int id;
+  final GroupResponse group;
+  final UserResponse inviter;
+  final UserResponse invitee;
+  final InviteStatus status;
+  final DateTime? createdAt;
+  final DateTime? respondedAt;
+
+  Invite({
+    required this.id,
+    required this.group,
+    required this.inviter,
+    required this.invitee,
+    required this.status,
+    required this.createdAt,
+    required this.respondedAt,
+  });
+
+  factory Invite.fromJson(Map<String, dynamic> json) {
+    return Invite(
+      id: json['id'] as int? ?? 0,
+      group: GroupResponse.fromJson(
+        json['group'] as Map<String, dynamic>? ?? {},
+      ),
+      inviter: UserResponse.fromJson(
+        json['inviter'] as Map<String, dynamic>? ?? {},
+      ),
+      invitee: UserResponse.fromJson(
+        json['invitee'] as Map<String, dynamic>? ?? {},
+      ),
+      status: InviteStatusMapper.fromBackend(json['status'] as String?),
+      createdAt: _parseDate(json['createdAt'] as String?),
+      respondedAt: _parseDate(json['respondedAt'] as String?),
+    );
+  }
+
+  static DateTime? _parseDate(String? value) {
+    if (value == null) {
+      return null;
+    }
+
+    try {
+      return DateTime.parse(value);
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+class PaginatedInvites {
+  final List<Invite> content;
+  final int page;
+  final int size;
+  final int totalElements;
+  final int totalPages;
+  final bool last;
+
+  const PaginatedInvites({
+    required this.content,
+    required this.page,
+    required this.size,
+    required this.totalElements,
+    required this.totalPages,
+    required this.last,
+  });
+
+  factory PaginatedInvites.fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return const PaginatedInvites(
+        content: [],
+        page: 1,
+        size: 0,
+        totalElements: 0,
+        totalPages: 0,
+        last: true,
+      );
+    }
+
+    return PaginatedInvites(
+      content: (json['content'] as List<dynamic>? ?? [])
+          .map((item) => Invite.fromJson(item as Map<String, dynamic>))
+          .toList(),
+      page: json['page'] as int? ?? 1,
+      size: json['size'] as int? ?? 0,
+      totalElements: json['totalElements'] as int? ?? 0,
+      totalPages: json['totalPages'] as int? ?? 0,
+      last: json['last'] as bool? ?? true,
+    );
+  }
+}
+
+class MyInvites {
+  final PaginatedInvites received;
+  final PaginatedInvites sent;
+
+  const MyInvites({
+    required this.received,
+    required this.sent,
+  });
+
+  factory MyInvites.fromJson(Map<String, dynamic> json) {
+    return MyInvites(
+      received: PaginatedInvites.fromJson(
+        json['received'] as Map<String, dynamic>?,
+      ),
+      sent: PaginatedInvites.fromJson(
+        json['sent'] as Map<String, dynamic>?,
+      ),
+    );
+  }
+}

--- a/lib/resources/comments_api.dart
+++ b/lib/resources/comments_api.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:booking_group_flutter/core/constants/api_constants.dart';
+import 'package:booking_group_flutter/models/comment.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CommentsApi {
+  Future<String?> _getBearerToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('bearerToken');
+  }
+
+  Future<List<Comment>> getCommentsByPost(int postId) async {
+    try {
+      final response = await http.get(
+        Uri.parse(ApiConstants.getPostCommentsUrl(postId)),
+        headers: {'accept': '*/*'},
+      );
+
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> jsonResponse = json.decode(response.body);
+        final List<dynamic> data = jsonResponse['data'] as List<dynamic>? ?? [];
+        return data
+            .map((item) => Comment.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw Exception(
+        'Failed to load comments: ${response.statusCode}',
+      );
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<Comment> createComment({
+    required int postId,
+    required String content,
+  }) async {
+    try {
+      final token = await _getBearerToken();
+      if (token == null) {
+        throw Exception('No authentication token found');
+      }
+
+      final response = await http.post(
+        Uri.parse(ApiConstants.commentsUrl),
+        headers: ApiConstants.authHeaders(token),
+        body: jsonEncode({
+          'postId': postId,
+          'content': content,
+        }),
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final Map<String, dynamic> jsonResponse = json.decode(response.body);
+        final data = jsonResponse['data'] as Map<String, dynamic>? ?? {};
+        return Comment.fromJson(data);
+      }
+
+      final Map<String, dynamic> errorResponse = json.decode(response.body);
+      final message = errorResponse['message'] ?? 'Failed to create comment';
+      throw Exception(message);
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/resources/invite_api.dart
+++ b/lib/resources/invite_api.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:booking_group_flutter/core/constants/api_constants.dart';
+import 'package:booking_group_flutter/models/invite.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class InviteApi {
+  Future<String?> _getBearerToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('bearerToken');
+  }
+
+  Future<Invite> createInvite({
+    required int groupId,
+    required int inviteeId,
+  }) async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('No authentication token found');
+    }
+
+    final response = await http.post(
+      Uri.parse(ApiConstants.invitesUrl),
+      headers: ApiConstants.authHeaders(token),
+      body: jsonEncode({
+        'groupId': groupId,
+        'inviteeId': inviteeId,
+      }),
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      final Map<String, dynamic> jsonResponse = json.decode(response.body);
+      final data = jsonResponse['data'] as Map<String, dynamic>? ?? {};
+      return Invite.fromJson(data);
+    }
+
+    final Map<String, dynamic> errorResponse = json.decode(response.body);
+    final message = errorResponse['message'] ?? 'Failed to create invite';
+    throw Exception(message);
+  }
+
+  Future<MyInvites> getMyInvites({
+    InviteStatus? status,
+    int receivedPage = 1,
+    int receivedSize = 10,
+    int sentPage = 1,
+    int sentSize = 10,
+  }) async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('No authentication token found');
+    }
+
+    final response = await http.get(
+      Uri.parse(
+        ApiConstants.getMyInvitesUrl(
+          status: status,
+          receivedPage: receivedPage,
+          receivedSize: receivedSize,
+          sentPage: sentPage,
+          sentSize: sentSize,
+        ),
+      ),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> jsonResponse = json.decode(response.body);
+      final data = jsonResponse['data'] as Map<String, dynamic>? ?? {};
+      return MyInvites.fromJson(data);
+    }
+
+    throw Exception('Failed to load invites: ${response.statusCode}');
+  }
+
+  Future<Invite> respondToInvite({
+    required int inviteId,
+    required InviteStatus status,
+  }) async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('No authentication token found');
+    }
+
+    final response = await http.patch(
+      Uri.parse(ApiConstants.updateInviteStatusUrl(inviteId)),
+      headers: ApiConstants.authHeaders(token),
+      body: jsonEncode({'status': status.backendValue}),
+    );
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> jsonResponse = json.decode(response.body);
+      final data = jsonResponse['data'] as Map<String, dynamic>? ?? {};
+      return Invite.fromJson(data);
+    }
+
+    final Map<String, dynamic> errorResponse = json.decode(response.body);
+    final message = errorResponse['message'] ?? 'Failed to update invite';
+    throw Exception(message);
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the forum page to use reusable post cards and add navigation to group detail
- add a comment bottom sheet that lets students comment and leaders review commenter profiles
- integrate invite and comment APIs, including new models and constants, so leaders can send group invites from forum discussions

## Testing
- Not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690077363ae0832f8a953f2200544e15