### PR TITLE
Align leader group actions with backend updates

### DIFF
--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -1,3 +1,5 @@
+import 'package:booking_group_flutter/models/invite.dart';
+
 /// API Constants - Centralized configuration for all API endpoints
 class ApiConstants {
   // Base URL
@@ -25,6 +27,56 @@ class ApiConstants {
 
   static const String myGroup = '/groups/my-group';
   static String get myGroupUrl => '$baseApiUrl$myGroup';
+
+  static const String updateGroup = '/groups/update';
+  static String get updateGroupUrl => '$baseApiUrl$updateGroup';
+
+  static const String changeGroupType = '/groups/change-type';
+  static String get changeGroupTypeUrl => '$baseApiUrl$changeGroupType';
+
+  static const String completeGroup = '/groups/done';
+  static String get completeGroupUrl => '$baseApiUrl$completeGroup';
+
+  // Invite Endpoints
+  static const String invites = '/invites';
+  static String get invitesUrl => '$baseApiUrl$invites';
+
+  static String getMyInvitesUrl({
+    InviteStatus? status,
+    int receivedPage = 1,
+    int receivedSize = 10,
+    int sentPage = 1,
+    int sentSize = 10,
+  }) {
+    final queryParameters = <String, String>{
+      'receivedPage': '$receivedPage',
+      'receivedSize': '$receivedSize',
+      'sentPage': '$sentPage',
+      'sentSize': '$sentSize',
+    };
+
+    if (status != null) {
+      queryParameters['status'] = status.name.toUpperCase();
+    }
+
+    final query = queryParameters.entries
+        .map((entry) => '${entry.key}=${entry.value}')
+        .join('&');
+
+    return '$baseApiUrl$invites/my?$query';
+  }
+
+  static String updateInviteStatusUrl(int inviteId) {
+    return '$baseApiUrl$invites/$inviteId';
+  }
+
+  // Comment Endpoints
+  static const String comments = '/comments';
+  static String get commentsUrl => '$baseApiUrl$comments';
+
+  static String getPostCommentsUrl(int postId) {
+    return '$baseApiUrl$comments/post/$postId';
+  }
 
   static String getGroupMembersUrl(int groupId) {
     return '$baseApiUrl$groups/$groupId/members';

--- a/lib/features/forum/presentation/pages/forum_page.dart
+++ b/lib/features/forum/presentation/pages/forum_page.dart
@@ -1,7 +1,15 @@
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comments_bottom_sheet.dart';
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_post_card.dart';
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comment_profile_sheet.dart';
+import 'package:booking_group_flutter/features/groups/presentation/pages/group_detail_page.dart';
+import 'package:booking_group_flutter/models/my_group.dart';
 import 'package:booking_group_flutter/models/post.dart';
 import 'package:booking_group_flutter/resources/forum_api.dart';
+import 'package:booking_group_flutter/resources/invite_api.dart';
+import 'package:booking_group_flutter/resources/my_group_api.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 
 class ForumPage extends StatefulWidget {
   const ForumPage({super.key});
@@ -12,27 +20,40 @@ class ForumPage extends StatefulWidget {
 
 class _ForumPageState extends State<ForumPage> {
   final ForumApi _forumApi = ForumApi();
+  final MyGroupApi _myGroupApi = MyGroupApi();
+  final InviteApi _inviteApi = InviteApi();
 
   List<Post> _posts = [];
   bool _isLoading = true;
   String? _error;
+  MyGroup? _myGroup;
+  bool _isLeader = false;
+  Set<int> _myGroupMemberIds = {};
+  final Map<int, bool> _inviteLoading = {};
+  final Set<int> _invitedUserIds = {};
+  String? _currentUserEmail;
 
   @override
   void initState() {
     super.initState();
-    _loadPosts();
+    _currentUserEmail = FirebaseAuth.instance.currentUser?.email;
+    _loadData();
   }
 
-  Future<void> _loadPosts() async {
+  Future<void> _loadData() async {
     setState(() {
       _isLoading = true;
       _error = null;
     });
 
     try {
-      final posts = await _forumApi.getAllPosts();
+      final results = await Future.wait<dynamic>([
+        _forumApi.getAllPosts(),
+        _loadLeadership(),
+      ]);
+
       setState(() {
-        _posts = posts;
+        _posts = results.first as List<Post>;
       });
     } catch (e) {
       setState(() {
@@ -45,34 +66,56 @@ class _ForumPageState extends State<ForumPage> {
     }
   }
 
-  String _formatDate(String dateStr) {
+  Future<void> _loadLeadership() async {
+    final currentEmail = _currentUserEmail;
+
+    if (currentEmail == null) {
+      if (!mounted) return;
+      setState(() {
+        _myGroup = null;
+        _isLeader = false;
+        _myGroupMemberIds = {};
+      });
+      return;
+    }
+
     try {
-      final date = DateTime.parse(dateStr);
-      return DateFormat('dd/MM/yyyy HH:mm').format(date);
+      final myGroup = await _myGroupApi.getMyGroup();
+      if (!mounted) return;
+
+      if (myGroup == null) {
+        setState(() {
+          _myGroup = null;
+          _isLeader = false;
+          _myGroupMemberIds = {};
+        });
+        return;
+      }
+
+      final leader = await _myGroupApi.getGroupLeader(myGroup.id);
+      final isLeader = leader != null && leader.email == currentEmail;
+
+      Set<int> memberIds = {};
+      if (isLeader) {
+        final members = await _myGroupApi.getGroupMembers(myGroup.id);
+        memberIds = members.map((member) => member.id).toSet();
+      }
+
+      if (!mounted) return;
+
+      setState(() {
+        _myGroup = myGroup;
+        _isLeader = isLeader;
+        _myGroupMemberIds = memberIds;
+      });
     } catch (e) {
-      return dateStr;
-    }
-  }
-
-  Color _getTypeColor(String type) {
-    switch (type.toUpperCase()) {
-      case 'FIND_GROUP':
-        return Colors.blue;
-      case 'FIND_MEMBER':
-        return Colors.green;
-      default:
-        return Colors.grey;
-    }
-  }
-
-  String _getTypeLabel(String type) {
-    switch (type.toUpperCase()) {
-      case 'FIND_GROUP':
-        return 'Tìm nhóm';
-      case 'FIND_MEMBER':
-        return 'Tìm thành viên';
-      default:
-        return type;
+      debugPrint('Error loading leadership data: $e');
+      if (!mounted) return;
+      setState(() {
+        _myGroup = null;
+        _isLeader = false;
+        _myGroupMemberIds = {};
+      });
     }
   }
 
@@ -96,7 +139,7 @@ class _ForumPageState extends State<ForumPage> {
                   Text(_error!, style: const TextStyle(color: Colors.grey)),
                   const SizedBox(height: 16),
                   ElevatedButton(
-                    onPressed: _loadPosts,
+                    onPressed: _loadData,
                     child: const Text('Thử lại'),
                   ),
                 ],
@@ -121,7 +164,7 @@ class _ForumPageState extends State<ForumPage> {
               ),
             )
           : RefreshIndicator(
-              onRefresh: _loadPosts,
+              onRefresh: _loadData,
               child: ListView.separated(
                 padding: const EdgeInsets.all(16),
                 itemCount: _posts.length,
@@ -129,127 +172,128 @@ class _ForumPageState extends State<ForumPage> {
                     const SizedBox(height: 12),
                 itemBuilder: (context, index) {
                   final post = _posts[index];
-                  return Card(
-                    elevation: 2,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          // Header: User info and type badge
-                          Row(
-                            children: [
-                              CircleAvatar(
-                                radius: 20,
-                                backgroundImage:
-                                    post.userResponse.avatarUrl != null
-                                    ? NetworkImage(post.userResponse.avatarUrl!)
-                                    : null,
-                                child: post.userResponse.avatarUrl == null
-                                    ? Text(
-                                        post.userResponse.fullName.isNotEmpty
-                                            ? post.userResponse.fullName
-                                                  .substring(0, 1)
-                                                  .toUpperCase()
-                                            : '?',
-                                        style: const TextStyle(
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      )
-                                    : null,
-                              ),
-                              const SizedBox(width: 12),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      post.userResponse.fullName,
-                                      style: const TextStyle(
-                                        fontWeight: FontWeight.bold,
-                                        fontSize: 16,
-                                      ),
-                                    ),
-                                    Text(
-                                      _formatDate(post.createdAt),
-                                      style: TextStyle(
-                                        color: Colors.grey.shade600,
-                                        fontSize: 12,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 12,
-                                  vertical: 6,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: _getTypeColor(
-                                    post.type,
-                                  ).withOpacity(0.1),
-                                  borderRadius: BorderRadius.circular(20),
-                                ),
-                                child: Text(
-                                  _getTypeLabel(post.type),
-                                  style: TextStyle(
-                                    color: _getTypeColor(post.type),
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 12,
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 12),
-
-                          // Content
-                          Text(
-                            post.content,
-                            style: const TextStyle(fontSize: 14),
-                          ),
-
-                          // Group info (if exists)
-                          if (post.groupResponse != null) ...[
-                            const SizedBox(height: 12),
-                            Container(
-                              padding: const EdgeInsets.all(12),
-                              decoration: BoxDecoration(
-                                color: Colors.grey.shade100,
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              child: Row(
-                                children: [
-                                  Icon(
-                                    Icons.group,
-                                    color: Colors.grey.shade600,
-                                    size: 20,
-                                  ),
-                                  const SizedBox(width: 8),
-                                  Expanded(
-                                    child: Text(
-                                      post.groupResponse!.title,
-                                      style: TextStyle(
-                                        color: Colors.grey.shade800,
-                                        fontWeight: FontWeight.w500,
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
+                  return ForumPostCard(
+                    post: post,
+                    onViewGroup: post.groupResponse != null
+                        ? () => _openGroupDetail(post)
+                        : null,
+                    onOpenComments: () => _openComments(post),
+                    onPosterTap: post.type.toUpperCase() == 'FIND_GROUP'
+                        ? () => _openPosterProfile(post)
+                        : null,
                   );
                 },
               ),
             ),
     );
+  }
+
+  void _openGroupDetail(Post post) {
+    final group = post.groupResponse;
+    if (group == null) return;
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => GroupDetailPage(
+          groupId: group.id,
+          groupTitle: group.title,
+        ),
+      ),
+    );
+  }
+
+  void _openComments(Post post) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (sheetContext) => ForumCommentsBottomSheet(
+        post: post,
+        parentContext: context,
+      ),
+    );
+  }
+
+  void _openPosterProfile(Post post) {
+    final user = post.userResponse;
+    final inviteeId = user.id;
+    final isSelf = _currentUserEmail != null &&
+        _currentUserEmail!.toLowerCase() == user.email.toLowerCase();
+    final isMember = _myGroupMemberIds.contains(inviteeId);
+    final alreadyInvited = _invitedUserIds.contains(inviteeId);
+    final group = _myGroup;
+    final canInvite = _isLeader && group != null && !isSelf;
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (sheetContext) => ForumCommentProfileSheet(
+        user: user,
+        note: post.content,
+        noteLabel: 'Nội dung bài đăng',
+        canInvite: canInvite && !isMember && !alreadyInvited,
+        isInviting: _inviteLoading[inviteeId] ?? false,
+        isMember: isMember,
+        alreadyInvited: alreadyInvited,
+        isSelf: isSelf,
+        onInvite: canInvite && !isMember && !alreadyInvited
+            ? () => _inviteFromPost(
+                  inviteeId: inviteeId,
+                  groupId: group!.id,
+                  sheetContext: sheetContext,
+                  displayName: user.fullName.isNotEmpty
+                      ? user.fullName
+                      : user.email,
+                )
+            : null,
+      ),
+    );
+  }
+
+  Future<void> _inviteFromPost({
+    required int inviteeId,
+    required int groupId,
+    required BuildContext sheetContext,
+    required String displayName,
+  }) async {
+    setState(() {
+      _inviteLoading[inviteeId] = true;
+    });
+
+    try {
+      await _inviteApi.createInvite(groupId: groupId, inviteeId: inviteeId);
+      if (!mounted) return;
+
+      setState(() {
+        _invitedUserIds.add(inviteeId);
+      });
+
+      Navigator.of(sheetContext).pop();
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Đã gửi lời mời đến $displayName'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(e.toString()),
+          backgroundColor: Colors.red,
+        ),
+      );
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _inviteLoading.remove(inviteeId);
+      });
+    }
   }
 }

--- a/lib/features/forum/presentation/widgets/forum_comment_input.dart
+++ b/lib/features/forum/presentation/widgets/forum_comment_input.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class ForumCommentInput extends StatelessWidget {
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final bool isSending;
+  final VoidCallback onSend;
+
+  const ForumCommentInput({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+    required this.isSending,
+    required this.onSend,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: controller,
+              focusNode: focusNode,
+              minLines: 1,
+              maxLines: 4,
+              textInputAction: TextInputAction.newline,
+              decoration: InputDecoration(
+                hintText: 'Viết bình luận...',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                isDense: true,
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          IconButton(
+            onPressed: isSending ? null : onSend,
+            icon: isSending
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.send),
+            color: const Color(0xFF8B5CF6),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/forum/presentation/widgets/forum_comment_profile_sheet.dart
+++ b/lib/features/forum/presentation/widgets/forum_comment_profile_sheet.dart
@@ -1,0 +1,188 @@
+import 'package:booking_group_flutter/models/post.dart';
+import 'package:flutter/material.dart';
+
+class ForumCommentProfileSheet extends StatelessWidget {
+  final UserResponse user;
+  final bool canInvite;
+  final bool isInviting;
+  final bool isMember;
+  final bool alreadyInvited;
+  final bool isSelf;
+  final VoidCallback? onInvite;
+  final String? note;
+  final String? noteLabel;
+
+  const ForumCommentProfileSheet({
+    super.key,
+    required this.user,
+    required this.canInvite,
+    required this.isInviting,
+    required this.isMember,
+    required this.alreadyInvited,
+    required this.isSelf,
+    this.onInvite,
+    this.note,
+    this.noteLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final avatarUrl = user.avatarUrl;
+    final hasAvatar = avatarUrl != null && avatarUrl.isNotEmpty;
+    final displayName = user.displayName;
+    final emailText = user.safeEmail;
+    final majorText = user.major;
+    final noteTitle = noteLabel ?? 'Thông tin liên quan';
+
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Column(
+                  children: [
+                    CircleAvatar(
+                      radius: 36,
+                      backgroundImage:
+                          hasAvatar ? NetworkImage(avatarUrl) : null,
+                      child: !hasAvatar
+                          ? Text(
+                              user.avatarInitial,
+                              style: const TextStyle(
+                                fontSize: 24,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            )
+                          : null,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      displayName,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      emailText,
+                      style: TextStyle(
+                        color: Colors.grey.shade600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 20),
+              if (note != null && note!.isNotEmpty)
+                Container(
+                  width: double.infinity,
+                  margin: const EdgeInsets.only(bottom: 16),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.grey.shade100,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        noteTitle,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Colors.grey.shade600,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        note!,
+                        style: const TextStyle(fontSize: 14),
+                      ),
+                    ],
+                  ),
+                ),
+              if (majorText != null && majorText.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.school_outlined, size: 20),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          majorText,
+                          style: const TextStyle(fontSize: 14),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              Row(
+                children: [
+                  const Icon(Icons.badge_outlined, size: 20),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      user.studentCode.isNotEmpty
+                          ? user.studentCode
+                          : 'Chưa có mã số',
+                      style: const TextStyle(fontSize: 14),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              if (isSelf)
+                const Text(
+                  'Đây là tài khoản của bạn.',
+                  style: TextStyle(color: Colors.grey),
+                )
+              else if (alreadyInvited)
+                const Text(
+                  'Bạn đã gửi lời mời đến sinh viên này.',
+                  style: TextStyle(color: Colors.grey),
+                )
+              else if (isMember)
+                const Text(
+                  'Sinh viên này đã ở trong nhóm của bạn.',
+                  style: TextStyle(color: Colors.grey),
+                )
+              else if (!canInvite)
+                const Text(
+                  'Bạn không có quyền mời sinh viên này.',
+                  style: TextStyle(color: Colors.grey),
+                )
+              else
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: isInviting ? null : onInvite,
+                    icon: isInviting
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.person_add_alt_1_outlined),
+                    label: Text(isInviting ? 'Đang gửi...' : 'Mời vào nhóm'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFF8B5CF6),
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/forum/presentation/widgets/forum_comment_tile.dart
+++ b/lib/features/forum/presentation/widgets/forum_comment_tile.dart
@@ -1,0 +1,105 @@
+import 'package:booking_group_flutter/models/comment.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class ForumCommentTile extends StatelessWidget {
+  final Comment comment;
+  final VoidCallback onProfileTap;
+  final bool canInvite;
+  final bool isMember;
+  final bool alreadyInvited;
+
+  const ForumCommentTile({
+    super.key,
+    required this.comment,
+    required this.onProfileTap,
+    required this.canInvite,
+    required this.isMember,
+    required this.alreadyInvited,
+  });
+
+  String _formatDate(String date) {
+    try {
+      final parsed = DateTime.parse(date);
+      return DateFormat('dd/MM/yyyy HH:mm').format(parsed);
+    } catch (_) {
+      return date;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = comment.userResponse;
+    final avatarUrl = user.avatarUrl;
+    final hasAvatar = avatarUrl != null && avatarUrl.isNotEmpty;
+    final displayName = user.displayName;
+
+    return ListTile(
+      leading: CircleAvatar(
+        radius: 20,
+        backgroundImage: hasAvatar ? NetworkImage(avatarUrl) : null,
+        child: !hasAvatar
+            ? Text(
+                user.avatarInitial,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              )
+            : null,
+      ),
+      title: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  displayName,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (user.major != null && user.major!.isNotEmpty)
+                  Text(
+                    user.major!,
+                    style: TextStyle(
+                      color: Colors.grey.shade600,
+                      fontSize: 12,
+                    ),
+                  ),
+                const SizedBox(height: 4),
+                Text(
+                  comment.content,
+                  style: const TextStyle(fontSize: 14),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Row(
+          children: [
+            Text(
+              _formatDate(comment.createdAt),
+              style: TextStyle(color: Colors.grey.shade600, fontSize: 12),
+            ),
+            const Spacer(),
+            TextButton(
+              onPressed: onProfileTap,
+              child: Text(
+                canInvite
+                    ? alreadyInvited
+                        ? 'Đã mời'
+                        : isMember
+                            ? 'Đã trong nhóm'
+                            : 'Xem hồ sơ'
+                    : 'Xem hồ sơ',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/forum/presentation/widgets/forum_comments_bottom_sheet.dart
+++ b/lib/features/forum/presentation/widgets/forum_comments_bottom_sheet.dart
@@ -1,0 +1,357 @@
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comment_input.dart';
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comment_profile_sheet.dart';
+import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comment_tile.dart';
+import 'package:booking_group_flutter/models/comment.dart';
+import 'package:booking_group_flutter/models/post.dart';
+import 'package:booking_group_flutter/resources/comments_api.dart';
+import 'package:booking_group_flutter/resources/groups_api.dart';
+import 'package:booking_group_flutter/resources/invite_api.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class ForumCommentsBottomSheet extends StatefulWidget {
+  final Post post;
+  final BuildContext parentContext;
+
+  const ForumCommentsBottomSheet({
+    super.key,
+    required this.post,
+    required this.parentContext,
+  });
+
+  @override
+  State<ForumCommentsBottomSheet> createState() =>
+      _ForumCommentsBottomSheetState();
+}
+
+class _ForumCommentsBottomSheetState extends State<ForumCommentsBottomSheet> {
+  final CommentsApi _commentsApi = CommentsApi();
+  final InviteApi _inviteApi = InviteApi();
+  final GroupsApi _groupsApi = GroupsApi();
+  final TextEditingController _commentController = TextEditingController();
+  final FocusNode _commentFocusNode = FocusNode();
+
+  List<Comment> _comments = [];
+  bool _isLoading = true;
+  bool _isSendingComment = false;
+  bool _canInvite = false;
+  String? _error;
+  int? _groupId;
+  Set<int> _groupMemberIds = {};
+  Set<int> _invitedUserIds = {};
+  Map<int, bool> _inviteLoading = {};
+  String? _currentUserEmail;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentUserEmail = FirebaseAuth.instance.currentUser?.email;
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      await Future.wait([
+        _loadComments(),
+        _evaluateInvitePermission(),
+      ]);
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _loadComments() async {
+    final comments = await _commentsApi.getCommentsByPost(widget.post.id);
+    if (mounted) {
+      setState(() {
+        _comments = comments;
+      });
+    }
+  }
+
+  Future<void> _evaluateInvitePermission() async {
+    final group = widget.post.groupResponse;
+    final currentEmail = _currentUserEmail;
+
+    if (group == null || currentEmail == null) {
+      _canInvite = false;
+      return;
+    }
+
+    try {
+      final leader = await _groupsApi.getGroupLeader(group.id);
+      final leaderEmail = leader != null ? leader['email'] as String? : null;
+      final isLeader = leaderEmail != null && leaderEmail == currentEmail;
+      final isPostOwner = widget.post.userResponse.email == currentEmail;
+
+      if (isLeader || isPostOwner) {
+        final members = await _groupsApi.getGroupMembers(group.id);
+        _groupMemberIds = members.map((member) => member.id).toSet();
+        _groupId = group.id;
+        _canInvite = true;
+      } else {
+        _canInvite = false;
+      }
+    } catch (e) {
+      debugPrint('Error evaluating invite permission: $e');
+      _canInvite = false;
+    }
+  }
+
+  bool _isMember(Comment comment) {
+    return _groupMemberIds.contains(comment.userResponse.id);
+  }
+
+  bool _isInvited(Comment comment) {
+    return _invitedUserIds.contains(comment.userResponse.id);
+  }
+
+  bool _isSelf(Comment comment) {
+    return comment.userResponse.email == _currentUserEmail;
+  }
+
+  Future<void> _submitComment() async {
+    final content = _commentController.text.trim();
+    if (content.isEmpty) {
+      return;
+    }
+
+    setState(() {
+      _isSendingComment = true;
+    });
+
+    try {
+      await _commentsApi.createComment(
+        postId: widget.post.id,
+        content: content,
+      );
+
+      _commentController.clear();
+      await _loadComments();
+      _commentFocusNode.requestFocus();
+    } catch (e) {
+      ScaffoldMessenger.of(widget.parentContext).showSnackBar(
+        SnackBar(
+          content: Text(e.toString()),
+          backgroundColor: Colors.red,
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSendingComment = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleInvite(Comment comment, BuildContext sheetContext) async {
+    if (!_canInvite || _groupId == null) {
+      return;
+    }
+
+    final inviteeId = comment.userResponse.id;
+    if (inviteeId == 0 || _isMember(comment) || _isInvited(comment)) {
+      return;
+    }
+
+    setState(() {
+      _inviteLoading[inviteeId] = true;
+    });
+
+    try {
+      await _inviteApi.createInvite(
+        groupId: _groupId!,
+        inviteeId: inviteeId,
+      );
+
+      if (mounted) {
+        setState(() {
+          _invitedUserIds.add(inviteeId);
+        });
+      }
+
+      if (Navigator.of(sheetContext).canPop()) {
+        Navigator.of(sheetContext).pop();
+      }
+
+      ScaffoldMessenger.of(widget.parentContext).showSnackBar(
+        const SnackBar(
+          content: Text('Đã gửi lời mời tham gia nhóm'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(widget.parentContext).showSnackBar(
+        SnackBar(
+          content: Text(e.toString()),
+          backgroundColor: Colors.red,
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _inviteLoading.remove(inviteeId);
+        });
+      }
+    }
+  }
+
+  Future<void> _openProfile(Comment comment) async {
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (sheetContext) {
+        final user = comment.userResponse;
+        return ForumCommentProfileSheet(
+          user: user,
+          canInvite: _canInvite &&
+              !_isMember(comment) &&
+              !_isInvited(comment) &&
+              !_isSelf(comment) &&
+              widget.post.groupResponse != null,
+          isInviting: _inviteLoading[comment.userResponse.id] ?? false,
+          isMember: _isMember(comment),
+          alreadyInvited: _isInvited(comment),
+          isSelf: _isSelf(comment),
+          note: comment.content,
+          noteLabel: 'Nội dung bình luận',
+          onInvite: _canInvite && widget.post.groupResponse != null
+              ? () => _handleInvite(comment, sheetContext)
+              : null,
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    _commentFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: FractionallySizedBox(
+        heightFactor: 0.85,
+        child: Column(
+          children: [
+            const SizedBox(height: 12),
+            Container(
+              width: 48,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade400,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  const Icon(Icons.forum_outlined),
+                  const SizedBox(width: 8),
+                  Text(
+                    'Bình luận bài viết',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const Spacer(),
+                  if (_canInvite && widget.post.groupResponse != null)
+                    const Icon(Icons.verified, color: Color(0xFF8B5CF6)),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: _isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : _error != null
+                      ? Center(
+                          child: Padding(
+                            padding: const EdgeInsets.all(24),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                const Icon(Icons.error_outline,
+                                    size: 48, color: Colors.redAccent),
+                                const SizedBox(height: 12),
+                                Text(
+                                  _error!,
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(color: Colors.redAccent),
+                                ),
+                              ],
+                            ),
+                          ),
+                        )
+                      : _comments.isEmpty
+                          ? Center(
+                              child: Padding(
+                                padding: const EdgeInsets.all(24),
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Icon(
+                                      Icons.chat_bubble_outline,
+                                      size: 48,
+                                      color: Colors.grey.shade500,
+                                    ),
+                                    const SizedBox(height: 12),
+                                    const Text('Chưa có bình luận nào.'),
+                                  ],
+                                ),
+                              ),
+                            )
+                          : ListView.separated(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 12,
+                              ),
+                              itemCount: _comments.length,
+                              separatorBuilder: (_, __) => const SizedBox(height: 8),
+                              itemBuilder: (context, index) {
+                                final comment = _comments[index];
+                                return ForumCommentTile(
+                                  comment: comment,
+                                  onProfileTap: () => _openProfile(comment),
+                                  canInvite: _canInvite &&
+                                      !_isSelf(comment) &&
+                                      widget.post.groupResponse != null,
+                                  isMember: _isMember(comment),
+                                  alreadyInvited: _isInvited(comment),
+                                );
+                              },
+                            ),
+            ),
+            const Divider(height: 1),
+            ForumCommentInput(
+              controller: _commentController,
+              focusNode: _commentFocusNode,
+              isSending: _isSendingComment,
+              onSend: _submitComment,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/forum/presentation/widgets/forum_post_card.dart
+++ b/lib/features/forum/presentation/widgets/forum_post_card.dart
@@ -1,0 +1,186 @@
+import 'package:booking_group_flutter/models/post.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class ForumPostCard extends StatelessWidget {
+  final Post post;
+  final VoidCallback? onViewGroup;
+  final VoidCallback? onOpenComments;
+  final VoidCallback? onPosterTap;
+
+  const ForumPostCard({
+    super.key,
+    required this.post,
+    this.onViewGroup,
+    this.onOpenComments,
+    this.onPosterTap,
+  });
+
+  Color _typeColor(String type) {
+    switch (type.toUpperCase()) {
+      case 'FIND_GROUP':
+        return Colors.blue;
+      case 'FIND_MEMBER':
+        return Colors.green;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  String _typeLabel(String type) {
+    switch (type.toUpperCase()) {
+      case 'FIND_GROUP':
+        return 'Tìm nhóm';
+      case 'FIND_MEMBER':
+        return 'Tìm thành viên';
+      default:
+        return type;
+    }
+  }
+
+  String _formatDate(String dateStr) {
+    try {
+      final date = DateTime.parse(dateStr);
+      return DateFormat('dd/MM/yyyy HH:mm').format(date);
+    } catch (_) {
+      return dateStr;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final typeColor = _typeColor(post.type);
+    final user = post.userResponse;
+    final avatarUrl = user.avatarUrl;
+    final hasAvatar = avatarUrl != null && avatarUrl.isNotEmpty;
+
+    final displayName = user.displayName;
+    final headerContent = Row(
+      children: [
+        CircleAvatar(
+          radius: 20,
+          backgroundImage: hasAvatar ? NetworkImage(avatarUrl) : null,
+          child: !hasAvatar
+              ? Text(
+                  user.avatarInitial,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                )
+              : null,
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                displayName,
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                ),
+              ),
+              Text(
+                _formatDate(post.createdAt),
+                style: TextStyle(
+                  color: Colors.grey.shade600,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: typeColor.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Text(
+            _typeLabel(post.type),
+            style: TextStyle(
+              color: typeColor,
+              fontWeight: FontWeight.bold,
+              fontSize: 12,
+            ),
+          ),
+        ),
+      ],
+    );
+
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (onPosterTap != null)
+              InkWell(
+                onTap: onPosterTap,
+                borderRadius: BorderRadius.circular(12),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: headerContent,
+                ),
+              )
+            else
+              headerContent,
+            const SizedBox(height: 12),
+            Text(
+              post.content,
+              style: const TextStyle(fontSize: 14),
+            ),
+            if (post.groupResponse != null) ...[
+              const SizedBox(height: 12),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade100,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.group,
+                      color: Colors.grey.shade600,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        post.groupResponse!.title,
+                        style: TextStyle(
+                          color: Colors.grey.shade800,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                if (onViewGroup != null)
+                  TextButton.icon(
+                    onPressed: onViewGroup,
+                    icon: const Icon(Icons.group_outlined),
+                    label: const Text('Xem nhóm'),
+                  ),
+                if (onViewGroup != null) const SizedBox(width: 12),
+                TextButton.icon(
+                  onPressed: onOpenComments,
+                  icon: const Icon(Icons.forum_outlined),
+                  label: const Text('Bình luận'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/groups/presentation/widgets/group_detail_leader_section.dart
+++ b/lib/features/groups/presentation/widgets/group_detail_leader_section.dart
@@ -17,6 +17,9 @@ class GroupDetailLeaderSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isFormingGroup = groupStatus.toUpperCase() == 'FORMING';
+    final leaderAvatar = _extractAvatarUrl(leader?['avatarUrl']);
+    final leaderMajor = _extractMajorName(leader?['major']);
+    final hasAvatar = leaderAvatar != null && leaderAvatar.isNotEmpty;
 
     return Card(
       elevation: 3,
@@ -82,10 +85,9 @@ class GroupDetailLeaderSection extends StatelessWidget {
                 children: [
                   CircleAvatar(
                     radius: 28,
-                    backgroundImage: leader!['avatarUrl'] != null
-                        ? NetworkImage(leader!['avatarUrl'])
-                        : null,
-                    child: leader!['avatarUrl'] == null
+                    backgroundImage:
+                        hasAvatar ? NetworkImage(leaderAvatar) : null,
+                    child: !hasAvatar
                         ? Text(
                             (leader!['fullName'] ?? '?')
                                 .substring(0, 1)
@@ -117,10 +119,10 @@ class GroupDetailLeaderSection extends StatelessWidget {
                             color: Colors.grey.shade600,
                           ),
                         ),
-                        if (leader!['major'] != null) ...[
+                        if (leaderMajor != null && leaderMajor.isNotEmpty) ...[
                           const SizedBox(height: 4),
                           Text(
-                            leader!['major'],
+                            leaderMajor,
                             style: TextStyle(
                               fontSize: 13,
                               color: Colors.grey.shade600,
@@ -137,4 +139,50 @@ class GroupDetailLeaderSection extends StatelessWidget {
       ),
     );
   }
+}
+
+String? _extractAvatarUrl(dynamic avatar) {
+  if (avatar == null) {
+    return null;
+  }
+
+  if (avatar is String && avatar.isNotEmpty) {
+    return avatar;
+  }
+
+  if (avatar is Map<String, dynamic>) {
+    final candidates = [
+      avatar['url'],
+      avatar['signedUrl'],
+      avatar['path'],
+      avatar['value'],
+    ];
+
+    for (final candidate in candidates) {
+      if (candidate is String && candidate.isNotEmpty) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+String? _extractMajorName(dynamic major) {
+  if (major == null) {
+    return null;
+  }
+
+  if (major is String && major.isNotEmpty) {
+    return major;
+  }
+
+  if (major is Map<String, dynamic>) {
+    final name = major['name'];
+    if (name is String && name.isNotEmpty) {
+      return name;
+    }
+  }
+
+  return null;
 }

--- a/lib/features/my_group/presentation/pages/my_group_detail_page.dart
+++ b/lib/features/my_group/presentation/pages/my_group_detail_page.dart
@@ -6,6 +6,7 @@ import 'package:booking_group_flutter/models/group_member.dart';
 import 'package:booking_group_flutter/models/my_group.dart';
 import 'package:booking_group_flutter/models/user_profile.dart';
 import 'package:booking_group_flutter/resources/my_group_api.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 class MyGroupDetailPage extends StatefulWidget {
@@ -23,10 +24,14 @@ class _MyGroupDetailPageState extends State<MyGroupDetailPage> {
   UserProfile? _leader;
   bool _isLoading = true;
   String? _error;
+  bool _isLeader = false;
+  bool _isPerformingAction = false;
+  String? _currentUserEmail;
 
   @override
   void initState() {
     super.initState();
+    _currentUserEmail = FirebaseAuth.instance.currentUser?.email;
     _loadGroupData();
   }
 
@@ -39,18 +44,30 @@ class _MyGroupDetailPageState extends State<MyGroupDetailPage> {
     try {
       final myGroup = await _myGroupApi.getMyGroup();
 
-      if (myGroup != null) {
-        final results = await Future.wait([
-          _myGroupApi.getGroupMembers(myGroup.id),
-          _myGroupApi.getGroupLeader(myGroup.id),
-        ]);
-
+      if (myGroup == null) {
         setState(() {
-          _myGroup = myGroup;
-          _members = results[0] as List<GroupMember>;
-          _leader = results[1] as UserProfile?;
+          _myGroup = null;
+          _members = [];
+          _leader = null;
+          _isLeader = false;
         });
+        return;
       }
+
+      final results = await Future.wait([
+        _myGroupApi.getGroupMembers(myGroup.id),
+        _myGroupApi.getGroupLeader(myGroup.id),
+      ]);
+
+      setState(() {
+        _myGroup = myGroup;
+        _members = results[0] as List<GroupMember>;
+        _leader = results[1] as UserProfile?;
+        final leaderEmail = _leader?.email.toLowerCase();
+        _isLeader = leaderEmail != null &&
+            _currentUserEmail != null &&
+            leaderEmail == _currentUserEmail!.toLowerCase();
+      });
     } catch (e) {
       // Retry once if it's a 500 error and we haven't retried yet
       if (e.toString().contains('500') && retryCount < 2) {
@@ -63,6 +80,7 @@ class _MyGroupDetailPageState extends State<MyGroupDetailPage> {
 
       setState(() {
         _error = e.toString();
+        _isLeader = false;
       });
     } finally {
       setState(() {
@@ -239,15 +257,226 @@ class _MyGroupDetailPageState extends State<MyGroupDetailPage> {
                     GroupInfoCard(
                       group: _myGroup!,
                       memberCount: _members.length,
+                      showLeaderActions: _isLeader,
+                      actionsEnabled: !_isPerformingAction,
+                      onEditInfo: _isLeader ? _handleEditGroupInfo : null,
+                      onToggleType:
+                          _isLeader ? _handleToggleGroupType : null,
+                      onCompleteGroup:
+                          _isLeader ? _handleCompleteGroup : null,
                     ),
                     const SizedBox(height: 24),
-                    MembersSection(members: _members, leader: _leader),
+                    MembersSection(
+                      members: _members,
+                      leader: _leader,
+                      currentUserEmail: _currentUserEmail,
+                    ),
                     const SizedBox(height: 24),
                     _buildIdeasCard(),
                   ],
                 ),
               ),
             ),
+    );
+  }
+
+  Future<void> _handleEditGroupInfo() async {
+    final group = _myGroup;
+    if (group == null || !_isLeader) return;
+
+    final updatedValues = await _showEditGroupDialog(group);
+    if (updatedValues == null) {
+      return;
+    }
+
+    await _performGroupAction(
+      () => _myGroupApi.updateGroupInfo(
+        groupId: group.id,
+        title: updatedValues['title']!,
+        description: updatedValues['description']!,
+      ),
+      successMessage: 'Đã cập nhật thông tin nhóm',
+    );
+  }
+
+  Future<void> _handleToggleGroupType() async {
+    final group = _myGroup;
+    if (group == null || !_isLeader) return;
+
+    final currentType = group.type.toUpperCase();
+    final nextType = currentType == 'PUBLIC' ? 'PRIVATE' : 'PUBLIC';
+    final confirmed = await _showConfirmationDialog(
+      title: 'Thay đổi trạng thái nhóm',
+      message:
+          'Bạn có chắc muốn chuyển nhóm sang chế độ ${nextType == 'PUBLIC' ? 'Công khai' : 'Riêng tư'}?',
+      confirmLabel: 'Xác nhận',
+    );
+
+    if (confirmed != true) {
+      return;
+    }
+
+    await _performGroupAction(
+      () => _myGroupApi.changeGroupType(),
+      successMessage:
+          'Đã chuyển trạng thái nhóm sang ${nextType == 'PUBLIC' ? 'Công khai' : 'Riêng tư'}',
+    );
+  }
+
+  Future<void> _handleCompleteGroup() async {
+    final group = _myGroup;
+    if (group == null || !_isLeader) return;
+
+    final confirmed = await _showConfirmationDialog(
+      title: 'Hoàn tất nhóm',
+      message:
+          'Khi hoàn tất, nhóm sẽ không thể thay đổi thành viên nữa. Bạn có chắc chắn?',
+      confirmLabel: 'Hoàn tất',
+    );
+
+    if (confirmed != true) {
+      return;
+    }
+
+    await _performGroupAction(
+      () => _myGroupApi.completeGroup(),
+      successMessage: 'Nhóm đã được đánh dấu hoàn tất',
+    );
+  }
+
+  Future<void> _performGroupAction(
+    Future<void> Function() action, {
+    required String successMessage,
+  }) async {
+    setState(() {
+      _isPerformingAction = true;
+    });
+
+    try {
+      await action();
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(successMessage),
+          backgroundColor: Colors.green,
+        ),
+      );
+
+      await _loadGroupData();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(e.toString()),
+          backgroundColor: Colors.red,
+        ),
+      );
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isPerformingAction = false;
+      });
+    }
+  }
+
+  Future<Map<String, String>?> _showEditGroupDialog(MyGroup group) async {
+    final titleController = TextEditingController(text: group.title);
+    final descriptionController =
+        TextEditingController(text: group.description);
+    String? errorMessage;
+
+    return showDialog<Map<String, String>>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (context, setStateDialog) {
+            return AlertDialog(
+              title: const Text('Cập nhật thông tin nhóm'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      controller: titleController,
+                      decoration: const InputDecoration(
+                        labelText: 'Tên nhóm',
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      controller: descriptionController,
+                      decoration: const InputDecoration(
+                        labelText: 'Mô tả nhóm',
+                      ),
+                      maxLines: 4,
+                    ),
+                    if (errorMessage != null) ...[
+                      const SizedBox(height: 12),
+                      Text(
+                        errorMessage!,
+                        style:
+                            const TextStyle(color: Colors.red, fontSize: 12),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: const Text('Hủy'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    final title = titleController.text.trim();
+                    final description = descriptionController.text.trim();
+
+                    if (title.isEmpty) {
+                      setStateDialog(() {
+                        errorMessage = 'Tên nhóm không được để trống';
+                      });
+                      return;
+                    }
+
+                    Navigator.of(dialogContext).pop({
+                      'title': title,
+                      'description': description,
+                    });
+                  },
+                  child: const Text('Lưu'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<bool?> _showConfirmationDialog({
+    required String title,
+    required String message,
+    required String confirmLabel,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(title),
+          content: Text(message),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Hủy'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(confirmLabel),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/my_group/presentation/widgets/group_info_card.dart
+++ b/lib/features/my_group/presentation/widgets/group_info_card.dart
@@ -5,11 +5,21 @@ import 'package:intl/intl.dart';
 class GroupInfoCard extends StatelessWidget {
   final MyGroup group;
   final int memberCount;
+  final bool showLeaderActions;
+  final bool actionsEnabled;
+  final VoidCallback? onEditInfo;
+  final VoidCallback? onToggleType;
+  final VoidCallback? onCompleteGroup;
 
   const GroupInfoCard({
     super.key,
     required this.group,
     required this.memberCount,
+    this.showLeaderActions = false,
+    this.actionsEnabled = true,
+    this.onEditInfo,
+    this.onToggleType,
+    this.onCompleteGroup,
   });
 
   String _formatDate(String dateStr) {
@@ -87,6 +97,38 @@ class GroupInfoCard extends StatelessWidget {
                     ),
                   ),
                 ),
+                if (showLeaderActions)
+                  PopupMenuButton<_GroupAction>(
+                    enabled: actionsEnabled,
+                    icon: const Icon(Icons.more_vert),
+                    onSelected: (action) {
+                      switch (action) {
+                        case _GroupAction.updateInfo:
+                          onEditInfo?.call();
+                          break;
+                        case _GroupAction.toggleType:
+                          onToggleType?.call();
+                          break;
+                        case _GroupAction.completeGroup:
+                          onCompleteGroup?.call();
+                          break;
+                      }
+                    },
+                    itemBuilder: (context) => const [
+                      PopupMenuItem<_GroupAction>(
+                        value: _GroupAction.updateInfo,
+                        child: Text('Cập nhật thông tin'),
+                      ),
+                      PopupMenuItem<_GroupAction>(
+                        value: _GroupAction.toggleType,
+                        child: Text('Thay đổi trạng thái nhóm'),
+                      ),
+                      PopupMenuItem<_GroupAction>(
+                        value: _GroupAction.completeGroup,
+                        child: Text('Hoàn tất nhóm'),
+                      ),
+                    ],
+                  ),
               ],
             ),
 
@@ -159,3 +201,5 @@ class GroupInfoCard extends StatelessWidget {
     );
   }
 }
+
+enum _GroupAction { updateInfo, toggleType, completeGroup }

--- a/lib/features/my_group/presentation/widgets/member_card.dart
+++ b/lib/features/my_group/presentation/widgets/member_card.dart
@@ -5,12 +5,20 @@ import 'package:flutter/material.dart';
 class MemberCard extends StatelessWidget {
   final GroupMember member;
   final UserProfile? leader;
+  final bool isCurrentUser;
 
-  const MemberCard({super.key, required this.member, this.leader});
+  const MemberCard({
+    super.key,
+    required this.member,
+    this.leader,
+    this.isCurrentUser = false,
+  });
 
   @override
   Widget build(BuildContext context) {
     final bool isLeader = leader?.email == member.email;
+    final avatarUrl = member.avatarUrl;
+    final hasAvatar = avatarUrl != null && avatarUrl.isNotEmpty;
 
     return Row(
       children: [
@@ -18,10 +26,8 @@ class MemberCard extends StatelessWidget {
         CircleAvatar(
           radius: 24,
           backgroundColor: const Color(0xFF8B5CF6).withOpacity(0.1),
-          backgroundImage: member.avatarUrl != null
-              ? NetworkImage(member.avatarUrl!)
-              : null,
-          child: member.avatarUrl == null
+          backgroundImage: hasAvatar ? NetworkImage(avatarUrl) : null,
+          child: !hasAvatar
               ? Text(
                   member.fullName[0].toUpperCase(),
                   style: const TextStyle(
@@ -96,6 +102,21 @@ class MemberCard extends StatelessWidget {
                 fontSize: 11,
                 color: Colors.blue.shade700,
                 fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        if (isCurrentUser)
+          Padding(
+            padding: const EdgeInsets.only(left: 8),
+            child: Tooltip(
+              message: 'Bạn',
+              child: Container(
+                width: 10,
+                height: 10,
+                decoration: const BoxDecoration(
+                  color: Color(0xFF8B5CF6),
+                  shape: BoxShape.circle,
+                ),
               ),
             ),
           ),

--- a/lib/features/my_group/presentation/widgets/members_section.dart
+++ b/lib/features/my_group/presentation/widgets/members_section.dart
@@ -7,8 +7,14 @@ import 'member_card.dart';
 class MembersSection extends StatelessWidget {
   final List<GroupMember> members;
   final UserProfile? leader;
+  final String? currentUserEmail;
 
-  const MembersSection({super.key, required this.members, this.leader});
+  const MembersSection({
+    super.key,
+    required this.members,
+    this.leader,
+    this.currentUserEmail,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -52,7 +58,15 @@ class MembersSection extends StatelessWidget {
                 separatorBuilder: (context, index) => const Divider(height: 24),
                 itemBuilder: (context, index) {
                   final member = members[index];
-                  return MemberCard(member: member, leader: leader);
+                  final isCurrentUser = currentUserEmail != null &&
+                      currentUserEmail!.toLowerCase() ==
+                          member.email.toLowerCase();
+
+                  return MemberCard(
+                    member: member,
+                    leader: leader,
+                    isCurrentUser: isCurrentUser,
+                  );
                 },
               ),
           ],

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -269,6 +269,7 @@ class _ProfilePageState extends State<ProfilePage> {
     final displayName = _googleName ?? _userProfile?.fullName ?? 'Người dùng';
     final displayEmail = _googleEmail ?? _userProfile?.email ?? '';
     final displayAvatar = _googleAvatar ?? _userProfile?.avatarUrl;
+    final hasAvatar = displayAvatar != null && displayAvatar.isNotEmpty;
 
     return SingleChildScrollView(
       child: Column(
@@ -306,10 +307,9 @@ class _ProfilePageState extends State<ProfilePage> {
                       CircleAvatar(
                         radius: 60,
                         backgroundColor: Colors.grey[200],
-                        backgroundImage: displayAvatar != null
-                            ? NetworkImage(displayAvatar)
-                            : null,
-                        child: displayAvatar == null
+                        backgroundImage:
+                            hasAvatar ? NetworkImage(displayAvatar) : null,
+                        child: !hasAvatar
                             ? Icon(
                                 Icons.person,
                                 size: 60,

--- a/lib/models/comment.dart
+++ b/lib/models/comment.dart
@@ -1,0 +1,33 @@
+import 'package:booking_group_flutter/models/post.dart';
+
+class Comment {
+  final int id;
+  final int postId;
+  final UserResponse userResponse;
+  final String content;
+  final String createdAt;
+  final bool active;
+
+  Comment({
+    required this.id,
+    required this.postId,
+    required this.userResponse,
+    required this.content,
+    required this.createdAt,
+    required this.active,
+  });
+
+  factory Comment.fromJson(Map<String, dynamic> json) {
+    final postJson = json['post'] as Map<String, dynamic>?;
+    final userJson = (json['userResponse'] ?? json['user']) as Map<String, dynamic>?;
+
+    return Comment(
+      id: json['id'] as int? ?? 0,
+      postId: json['postId'] as int? ?? postJson?['id'] as int? ?? 0,
+      userResponse: UserResponse.fromJson(userJson ?? {}),
+      content: json['content'] as String? ?? '',
+      createdAt: json['createdAt'] as String? ?? '',
+      active: json['active'] as bool? ?? true,
+    );
+  }
+}

--- a/lib/models/group_member.dart
+++ b/lib/models/group_member.dart
@@ -31,7 +31,7 @@ class GroupMember {
       fullName: json['fullName'] as String,
       email: json['email'] as String,
       cwu: json['cwu'] as String?,
-      avatarUrl: json['avatarUrl'] as String?,
+      avatarUrl: _extractAvatarUrl(json['avatarUrl']),
       major: json['major'] != null ? Major.fromJson(json['major']) : null,
       role: json['role'] as String,
       isActive: json['isActive'] as bool? ?? true,
@@ -54,4 +54,31 @@ class GroupMember {
 
   String get displayName => fullName;
   String get identifier => studentCode ?? email;
+}
+
+String? _extractAvatarUrl(dynamic avatar) {
+  if (avatar == null) {
+    return null;
+  }
+
+  if (avatar is String && avatar.isNotEmpty) {
+    return avatar;
+  }
+
+  if (avatar is Map<String, dynamic>) {
+    final candidates = [
+      avatar['url'],
+      avatar['signedUrl'],
+      avatar['path'],
+      avatar['value'],
+    ];
+
+    for (final candidate in candidates) {
+      if (candidate is String && candidate.isNotEmpty) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
 }

--- a/lib/models/invite.dart
+++ b/lib/models/invite.dart
@@ -1,0 +1,141 @@
+import 'package:booking_group_flutter/models/post.dart';
+
+enum InviteStatus { pending, accepted, declined }
+
+extension InviteStatusMapper on InviteStatus {
+  String get backendValue {
+    switch (this) {
+      case InviteStatus.pending:
+        return 'PENDING';
+      case InviteStatus.accepted:
+        return 'ACCEPTED';
+      case InviteStatus.declined:
+        return 'DECLINED';
+    }
+  }
+
+  static InviteStatus fromBackend(String? value) {
+    switch (value?.toUpperCase()) {
+      case 'ACCEPTED':
+        return InviteStatus.accepted;
+      case 'DECLINED':
+        return InviteStatus.declined;
+      case 'PENDING':
+      default:
+        return InviteStatus.pending;
+    }
+  }
+}
+
+class Invite {
+  final int id;
+  final GroupResponse group;
+  final UserResponse inviter;
+  final UserResponse invitee;
+  final InviteStatus status;
+  final DateTime? createdAt;
+  final DateTime? respondedAt;
+
+  Invite({
+    required this.id,
+    required this.group,
+    required this.inviter,
+    required this.invitee,
+    required this.status,
+    required this.createdAt,
+    required this.respondedAt,
+  });
+
+  factory Invite.fromJson(Map<String, dynamic> json) {
+    return Invite(
+      id: json['id'] as int? ?? 0,
+      group: GroupResponse.fromJson(
+        json['group'] as Map<String, dynamic>? ?? {},
+      ),
+      inviter: UserResponse.fromJson(
+        json['inviter'] as Map<String, dynamic>? ?? {},
+      ),
+      invitee: UserResponse.fromJson(
+        json['invitee'] as Map<String, dynamic>? ?? {},
+      ),
+      status: InviteStatusMapper.fromBackend(json['status'] as String?),
+      createdAt: _parseDate(json['createdAt'] as String?),
+      respondedAt: _parseDate(json['respondedAt'] as String?),
+    );
+  }
+
+  static DateTime? _parseDate(String? value) {
+    if (value == null) {
+      return null;
+    }
+
+    try {
+      return DateTime.parse(value);
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+class PaginatedInvites {
+  final List<Invite> content;
+  final int page;
+  final int size;
+  final int totalElements;
+  final int totalPages;
+  final bool last;
+
+  const PaginatedInvites({
+    required this.content,
+    required this.page,
+    required this.size,
+    required this.totalElements,
+    required this.totalPages,
+    required this.last,
+  });
+
+  factory PaginatedInvites.fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return const PaginatedInvites(
+        content: [],
+        page: 1,
+        size: 0,
+        totalElements: 0,
+        totalPages: 0,
+        last: true,
+      );
+    }
+
+    return PaginatedInvites(
+      content: (json['content'] as List<dynamic>? ?? [])
+          .map((item) => Invite.fromJson(item as Map<String, dynamic>))
+          .toList(),
+      page: json['page'] as int? ?? 1,
+      size: json['size'] as int? ?? 0,
+      totalElements: json['totalElements'] as int? ?? 0,
+      totalPages: json['totalPages'] as int? ?? 0,
+      last: json['last'] as bool? ?? true,
+    );
+  }
+}
+
+class MyInvites {
+  final PaginatedInvites received;
+  final PaginatedInvites sent;
+
+  const MyInvites({
+    required this.received,
+    required this.sent,
+  });
+
+  factory MyInvites.fromJson(Map<String, dynamic> json) {
+    return MyInvites(
+      received: PaginatedInvites.fromJson(
+        json['received'] as Map<String, dynamic>?,
+      ),
+      sent: PaginatedInvites.fromJson(
+        json['sent'] as Map<String, dynamic>?,
+      ),
+    );
+  }
+}

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -61,12 +61,90 @@ class UserResponse {
       studentCode: json['studentCode'] ?? '',
       fullName: json['fullName'] ?? '',
       email: json['email'] ?? '',
-      prefix: json['prefix'],
-      avatarUrl: json['avatarUrl'],
-      major: json['major'],
+      prefix: _stringOrNull(json['prefix']),
+      avatarUrl: _extractAvatarUrl(json['avatarUrl']),
+      major: _extractMajor(json['major']),
       role: json['role'] ?? 'STUDENT',
       isActive: json['isActive'] ?? true,
     );
+  }
+
+  String get displayName {
+    if (fullName.isNotEmpty) {
+      return fullName;
+    }
+    if (email.isNotEmpty) {
+      return email;
+    }
+    return 'Ẩn danh';
+  }
+
+  String get safeEmail {
+    if (email.isNotEmpty) {
+      return email;
+    }
+    return 'Chưa cung cấp email';
+  }
+
+  String get avatarInitial {
+    final trimmed = displayName.trim();
+    if (trimmed.isNotEmpty) {
+      return trimmed.substring(0, 1).toUpperCase();
+    }
+    return '?';
+  }
+
+  static String? _extractMajor(dynamic major) {
+    if (major == null) {
+      return null;
+    }
+
+    if (major is String) {
+      return major;
+    }
+
+    if (major is Map<String, dynamic>) {
+      final name = major['name'];
+      if (name is String && name.isNotEmpty) {
+        return name;
+      }
+    }
+
+    return null;
+  }
+
+  static String? _extractAvatarUrl(dynamic avatar) {
+    if (avatar == null) {
+      return null;
+    }
+
+    if (avatar is String && avatar.isNotEmpty) {
+      return avatar;
+    }
+
+    if (avatar is Map<String, dynamic>) {
+      final candidates = [
+        avatar['url'],
+        avatar['signedUrl'],
+        avatar['path'],
+        avatar['value'],
+      ];
+
+      for (final candidate in candidates) {
+        if (candidate is String && candidate.isNotEmpty) {
+          return candidate;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  static String? _stringOrNull(dynamic value) {
+    if (value is String && value.isNotEmpty) {
+      return value;
+    }
+    return null;
   }
 }
 

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -27,7 +27,7 @@ class UserProfile {
       fullName: json['fullName'] as String? ?? '',
       email: json['email'] as String? ?? '',
       cwu: json['cwu'] as String?,
-      avatarUrl: json['avatarUrl'] as String?,
+      avatarUrl: _extractAvatarUrl(json['avatarUrl']),
       major: json['major'] != null ? Major.fromJson(json['major']) : null,
       role: json['role'] as String? ?? 'STUDENT',
       isActive: json['isActive'] as bool? ?? true,
@@ -61,4 +61,31 @@ class UserProfile {
     }
     return 'Không rõ mã số';
   }
+}
+
+String? _extractAvatarUrl(dynamic avatar) {
+  if (avatar == null) {
+    return null;
+  }
+
+  if (avatar is String && avatar.isNotEmpty) {
+    return avatar;
+  }
+
+  if (avatar is Map<String, dynamic>) {
+    final candidates = [
+      avatar['url'],
+      avatar['signedUrl'],
+      avatar['path'],
+      avatar['value'],
+    ];
+
+    for (final candidate in candidates) {
+      if (candidate is String && candidate.isNotEmpty) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
 }

--- a/lib/resources/comments_api.dart
+++ b/lib/resources/comments_api.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:booking_group_flutter/core/constants/api_constants.dart';
+import 'package:booking_group_flutter/models/comment.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CommentsApi {
+  Future<String?> _getBearerToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('bearerToken');
+  }
+
+  Future<List<Comment>> getCommentsByPost(int postId) async {
+    try {
+      final response = await http.get(
+        Uri.parse(ApiConstants.getPostCommentsUrl(postId)),
+        headers: {'accept': '*/*'},
+      );
+
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> jsonResponse = json.decode(response.body);
+        final List<dynamic> data = jsonResponse['data'] as List<dynamic>? ?? [];
+        return data
+            .map((item) => Comment.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+
+      throw Exception(
+        'Failed to load comments: ${response.statusCode}',
+      );
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<Comment> createComment({
+    required int postId,
+    required String content,
+  }) async {
+    try {
+      final token = await _getBearerToken();
+      if (token == null) {
+        throw Exception('No authentication token found');
+      }
+
+      final response = await http.post(
+        Uri.parse(ApiConstants.commentsUrl),
+        headers: ApiConstants.authHeaders(token),
+        body: jsonEncode({
+          'postId': postId,
+          'content': content,
+        }),
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final Map<String, dynamic> jsonResponse = json.decode(response.body);
+        final data = jsonResponse['data'] as Map<String, dynamic>? ?? {};
+        return Comment.fromJson(data);
+      }
+
+      final Map<String, dynamic> errorResponse = json.decode(response.body);
+      final message = errorResponse['message'] ?? 'Failed to create comment';
+      throw Exception(message);
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/resources/invite_api.dart
+++ b/lib/resources/invite_api.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:booking_group_flutter/core/constants/api_constants.dart';
+import 'package:booking_group_flutter/models/invite.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class InviteApi {
+  Future<String?> _getBearerToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('bearerToken');
+  }
+
+  Future<Invite> createInvite({
+    required int groupId,
+    required int inviteeId,
+  }) async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('No authentication token found');
+    }
+
+    final response = await http.post(
+      Uri.parse(ApiConstants.invitesUrl),
+      headers: ApiConstants.authHeaders(token),
+      body: jsonEncode({
+        'groupId': groupId,
+        'inviteeId': inviteeId,
+      }),
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      final Map<String, dynamic> jsonResponse = json.decode(response.body);
+      final data = jsonResponse['data'] as Map<String, dynamic>? ?? {};
+      return Invite.fromJson(data);
+    }
+
+    final Map<String, dynamic> errorResponse = json.decode(response.body);
+    final message = errorResponse['message'] ?? 'Failed to create invite';
+    throw Exception(message);
+  }
+
+  Future<MyInvites> getMyInvites({
+    InviteStatus? status,
+    int receivedPage = 1,
+    int receivedSize = 10,
+    int sentPage = 1,
+    int sentSize = 10,
+  }) async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('No authentication token found');
+    }
+
+    final response = await http.get(
+      Uri.parse(
+        ApiConstants.getMyInvitesUrl(
+          status: status,
+          receivedPage: receivedPage,
+          receivedSize: receivedSize,
+          sentPage: sentPage,
+          sentSize: sentSize,
+        ),
+      ),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> jsonResponse = json.decode(response.body);
+      final data = jsonResponse['data'] as Map<String, dynamic>? ?? {};
+      return MyInvites.fromJson(data);
+    }
+
+    throw Exception('Failed to load invites: ${response.statusCode}');
+  }
+
+  Future<Invite> respondToInvite({
+    required int inviteId,
+    required InviteStatus status,
+  }) async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('No authentication token found');
+    }
+
+    final response = await http.patch(
+      Uri.parse(ApiConstants.updateInviteStatusUrl(inviteId)),
+      headers: ApiConstants.authHeaders(token),
+      body: jsonEncode({'status': status.backendValue}),
+    );
+
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> jsonResponse = json.decode(response.body);
+      final data = jsonResponse['data'] as Map<String, dynamic>? ?? {};
+      return Invite.fromJson(data);
+    }
+
+    final Map<String, dynamic> errorResponse = json.decode(response.body);
+    final message = errorResponse['message'] ?? 'Failed to update invite';
+    throw Exception(message);
+  }
+}

--- a/lib/resources/my_group_api.dart
+++ b/lib/resources/my_group_api.dart
@@ -224,6 +224,75 @@ class MyGroupApi {
     }
   }
 
+  Future<void> updateGroupInfo({
+    required int groupId,
+    required String title,
+    required String description,
+  }) async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('No authentication token found');
+    }
+
+    final response = await http.put(
+      Uri.parse(ApiConstants.updateGroupUrl),
+      headers: ApiConstants.authHeaders(token),
+      body: jsonEncode({
+        'groupId': groupId,
+        'title': title,
+        'description': description,
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      return;
+    }
+
+    final Map<String, dynamic> errorBody = jsonDecode(response.body);
+    final message = errorBody['message'] ?? 'Không thể cập nhật thông tin nhóm';
+    throw Exception(message);
+  }
+
+  Future<void> changeGroupType() async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('No authentication token found');
+    }
+
+    final response = await http.patch(
+      Uri.parse(ApiConstants.changeGroupTypeUrl),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode == 200) {
+      return;
+    }
+
+    final Map<String, dynamic> errorBody = jsonDecode(response.body);
+    final message = errorBody['message'] ?? 'Không thể thay đổi trạng thái nhóm';
+    throw Exception(message);
+  }
+
+  Future<void> completeGroup() async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('No authentication token found');
+    }
+
+    final response = await http.patch(
+      Uri.parse(ApiConstants.completeGroupUrl),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode == 200) {
+      return;
+    }
+
+    final Map<String, dynamic> errorBody = jsonDecode(response.body);
+    final message = errorBody['message'] ?? 'Không thể hoàn tất nhóm';
+    throw Exception(message);
+  }
+
   /// Create a new idea (Leader only)
   Future<bool> createIdea({
     required String title,


### PR DESCRIPTION
## Summary
- update leader-only actions to call the revised backend endpoints without sending unused payloads
- improve forum post and comment profile displays so avatars, names, and related content always appear with safe fallbacks
- centralize user display helpers to avoid runtime type errors when backend returns nested objects

## Testing
- Not run (Flutter is not installed in the container)


------
https://chatgpt.com/codex/tasks/task_e_690077363ae0832f8a953f2200544e15