### PR TITLE
Fix profile token lookup and highlight latest join request

### DIFF
--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -78,6 +78,14 @@ class ApiConstants {
     return '$baseApiUrl$comments/post/$postId';
   }
 
+  // Notification Endpoints
+  static const String notifications = '/notifications';
+  static String get notificationsUrl => '$baseApiUrl$notifications';
+
+  static String markNotificationAsReadUrl(int notificationId) {
+    return '$baseApiUrl$notifications/$notificationId/read';
+  }
+
   static String getGroupMembersUrl(int groupId) {
     return '$baseApiUrl$groups/$groupId/members';
   }

--- a/lib/features/home/presentation/widgets/your_request_section_card.dart
+++ b/lib/features/home/presentation/widgets/your_request_section_card.dart
@@ -4,11 +4,19 @@ import 'package:flutter/material.dart';
 class YourRequestSectionCard extends StatelessWidget {
   final int requestCount;
   final VoidCallback onTap;
+  final String? latestGroupTitle;
+  final String? latestStatusLabel;
+  final String? latestTimeLabel;
+  final bool showLatestRequestHighlight;
 
   const YourRequestSectionCard({
     super.key,
     required this.requestCount,
     required this.onTap,
+    this.latestGroupTitle,
+    this.latestStatusLabel,
+    this.latestTimeLabel,
+    this.showLatestRequestHighlight = false,
   });
 
   @override
@@ -141,6 +149,83 @@ class YourRequestSectionCard extends StatelessWidget {
                     ),
                     textAlign: TextAlign.center,
                   ),
+
+                  if (showLatestRequestHighlight && latestGroupTitle != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 18.0),
+                      child: Container(
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withOpacity(0.14),
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Container(
+                              padding: const EdgeInsets.all(8),
+                              decoration: BoxDecoration(
+                                color: Colors.white.withOpacity(0.2),
+                                shape: BoxShape.circle,
+                              ),
+                              child: const Icon(
+                                Icons.group_add_rounded,
+                                color: Colors.white,
+                                size: 22,
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  const Text(
+                                    'Bạn vừa gửi yêu cầu tới',
+                                    style: TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 14,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    latestGroupTitle!,
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 16,
+                                    ),
+                                  ),
+                                  if (latestStatusLabel != null)
+                                    Padding(
+                                      padding: const EdgeInsets.only(top: 6.0),
+                                      child: Text(
+                                        latestStatusLabel!,
+                                        style: TextStyle(
+                                          color: Colors.orange.shade100,
+                                          fontSize: 13,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                  if (latestTimeLabel != null)
+                                    Padding(
+                                      padding: const EdgeInsets.only(top: 4.0),
+                                      child: Text(
+                                        latestTimeLabel!,
+                                        style: TextStyle(
+                                          color: Colors.white.withOpacity(0.8),
+                                          fontSize: 12,
+                                        ),
+                                      ),
+                                    ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
                 ],
               ),
             ),

--- a/lib/features/notifications/application/notification_controller.dart
+++ b/lib/features/notifications/application/notification_controller.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:booking_group_flutter/models/app_notification.dart';
+import 'package:booking_group_flutter/resources/notifications_api.dart';
+import 'package:flutter/foundation.dart';
+
+class NotificationController extends ChangeNotifier {
+  NotificationController({NotificationsApi? api})
+      : _api = api ?? NotificationsApi();
+
+  final NotificationsApi _api;
+
+  final List<AppNotification> _notifications = [];
+  bool _isLoading = false;
+  String? _errorMessage;
+  bool _initialized = false;
+
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+  bool get initialized => _initialized;
+
+  List<AppNotification> get notifications => List.unmodifiable(_notifications);
+
+  int get unreadCount =>
+      _notifications.where((notification) => notification.isUnread).length;
+
+  Future<void> loadNotifications() async {
+    if (_isLoading) return;
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final results = await _api.fetchNotifications();
+      _notifications
+        ..clear()
+        ..addAll(results);
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        print('Failed to load notifications: $error');
+        print(stackTrace);
+      }
+      _errorMessage = error.toString();
+    } finally {
+      _isLoading = false;
+      _initialized = true;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refreshNotifications() async {
+    _initialized = false;
+    await loadNotifications();
+  }
+
+  Future<void> markNotificationAsRead(AppNotification notification) async {
+    if (notification.isRead) return;
+
+    final index = _notifications.indexWhere((item) => item.id == notification.id);
+    if (index == -1) return;
+
+    _notifications[index] = notification.copyWith(isRead: true);
+    notifyListeners();
+
+    try {
+      final updated = await _api.markAsRead(notification.id);
+      _notifications[index] = notification.copyWith(
+        title: updated.title.isNotEmpty ? updated.title : null,
+        message: updated.message.isNotEmpty ? updated.message : null,
+        isRead: updated.isRead,
+        createdAt: updated.createdAt ?? notification.createdAt,
+      );
+      notifyListeners();
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        print('Failed to mark notification as read: $error');
+        print(stackTrace);
+      }
+      _notifications[index] = notification;
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  Future<void> markAllAsRead() async {
+    final unread =
+        _notifications.where((notification) => notification.isUnread).toList();
+    if (unread.isEmpty) return;
+
+    for (final notification in unread) {
+      await markNotificationAsRead(notification);
+    }
+  }
+}

--- a/lib/features/notifications/presentation/widgets/notification_tile.dart
+++ b/lib/features/notifications/presentation/widgets/notification_tile.dart
@@ -1,0 +1,158 @@
+import 'package:booking_group_flutter/app/theme/app_theme.dart';
+import 'package:booking_group_flutter/models/app_notification.dart';
+import 'package:flutter/material.dart';
+
+class NotificationTile extends StatelessWidget {
+  const NotificationTile({
+    super.key,
+    required this.notification,
+    required this.timeLabel,
+    required this.selectionMode,
+    required this.selected,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  final AppNotification notification;
+  final String timeLabel;
+  final bool selectionMode;
+  final bool selected;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: BoxDecoration(
+        color: selectionMode && selected
+            ? AppTheme.primaryDark.withOpacity(0.08)
+            : Colors.grey.shade100,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(20),
+        onTap: onTap,
+        onLongPress: onLongPress,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 200),
+                transitionBuilder: (child, animation) =>
+                    ScaleTransition(scale: animation, child: child),
+                child: selectionMode
+                    ? SelectionIndicator(selected: selected)
+                    : NotificationLeadingIcon(unread: notification.isUnread),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            notification.title,
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleMedium
+                                ?.copyWith(fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Text(
+                          timeLabel,
+                          style:
+                              Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Colors.grey.shade600,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                        ),
+                        if (notification.isUnread)
+                          Container(
+                            margin: const EdgeInsets.only(left: 8),
+                            height: 8,
+                            width: 8,
+                            decoration: const BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Color(0xFF3366FF),
+                            ),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      notification.message,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.copyWith(color: Colors.grey.shade600),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class NotificationLeadingIcon extends StatelessWidget {
+  const NotificationLeadingIcon({super.key, required this.unread});
+
+  final bool unread;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 44,
+      height: 44,
+      decoration: BoxDecoration(
+        color: unread
+            ? const Color.fromRGBO(51, 102, 255, 0.12)
+            : Colors.grey.shade200,
+        shape: BoxShape.circle,
+      ),
+      child: Icon(
+        unread ? Icons.notifications_active : Icons.notifications_none,
+        color: unread ? const Color(0xFF3366FF) : Colors.grey.shade600,
+        size: 22,
+      ),
+    );
+  }
+}
+
+class SelectionIndicator extends StatelessWidget {
+  const SelectionIndicator({super.key, required this.selected});
+
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 44,
+      height: 44,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: selected ? const Color(0xFF3366FF) : Colors.grey.shade400,
+          width: 2,
+        ),
+      ),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        margin: const EdgeInsets.all(6),
+        decoration: BoxDecoration(
+          color: selected ? const Color(0xFF3366FF) : Colors.transparent,
+          shape: BoxShape.circle,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/notifications/presentation/widgets/notifications_app_bar.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_app_bar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+class NotificationsAppBar extends StatelessWidget {
+  const NotificationsAppBar({
+    super.key,
+    this.onBack,
+    required this.onSelectMode,
+  });
+
+  final VoidCallback? onBack;
+  final VoidCallback onSelectMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          RoundIconButton(
+            icon: Icons.arrow_back_ios_new,
+            onTap: onBack,
+          ),
+          Expanded(
+            child: Center(
+              child: Text(
+                'Notification',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+            ),
+          ),
+          PopupMenuButton<_NotificationMenu>(
+            onSelected: (value) {
+              if (value == _NotificationMenu.select) {
+                onSelectMode();
+              }
+            },
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            itemBuilder: (context) => [
+              PopupMenuItem<_NotificationMenu>(
+                value: _NotificationMenu.select,
+                child: Row(
+                  children: [
+                    Icon(Icons.done_all, color: Colors.grey.shade700, size: 20),
+                    const SizedBox(width: 12),
+                    const Text('Select notifications'),
+                  ],
+                ),
+              ),
+            ],
+            child: const RoundIconButton(
+              icon: Icons.more_horiz,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+enum _NotificationMenu { select }
+
+class RoundIconButton extends StatelessWidget {
+  const RoundIconButton({super.key, required this.icon, this.onTap});
+
+  final IconData icon;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: Ink(
+        width: 42,
+        height: 42,
+        decoration: BoxDecoration(
+          color: Colors.grey.shade200,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Icon(icon, size: 20, color: Colors.grey.shade700),
+      ),
+    );
+  }
+}

--- a/lib/features/notifications/presentation/widgets/section_header.dart
+++ b/lib/features/notifications/presentation/widgets/section_header.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class NotificationSectionHeader extends StatelessWidget {
+  const NotificationSectionHeader({
+    super.key,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context)
+              .textTheme
+              .titleMedium
+              ?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          subtitle,
+          style: Theme.of(context)
+              .textTheme
+              .bodySmall
+              ?.copyWith(color: Colors.grey.shade600),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/notifications/presentation/widgets/selection_toolbar.dart
+++ b/lib/features/notifications/presentation/widgets/selection_toolbar.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class SelectionToolbar extends StatelessWidget {
+  const SelectionToolbar({
+    super.key,
+    required this.allSelected,
+    required this.selectedCount,
+    required this.onSelectAll,
+    required this.onDelete,
+  });
+
+  final bool allSelected;
+  final int selectedCount;
+  final ValueChanged<bool?> onSelectAll;
+  final VoidCallback? onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Row(
+        children: [
+          Checkbox(
+            value: allSelected,
+            onChanged: onSelectAll,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              selectedCount > 0
+                  ? '$selectedCount notifications selected'
+                  : 'Select notifications',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          TextButton.icon(
+            onPressed: onDelete,
+            icon: const Icon(Icons.delete_outline),
+            label: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -62,7 +62,7 @@ class _ProfilePageState extends State<ProfilePage> {
 
       // 2. Lấy thông tin từ Backend API (major, studentCode, etc.)
       final prefs = await SharedPreferences.getInstance();
-      final token = prefs.getString('bearer_token');
+      final token = prefs.getString('bearerToken');
 
       if (token != null) {
         try {
@@ -129,7 +129,7 @@ class _ProfilePageState extends State<ProfilePage> {
       await FirebaseAuth.instance.signOut();
       // Xóa token từ SharedPreferences
       final prefs = await SharedPreferences.getInstance();
-      await prefs.remove('bearer_token');
+      await prefs.remove('bearerToken');
       await prefs.remove('user_email');
 
       if (mounted) {

--- a/lib/features/shell/presentation/pages/app_shell.dart
+++ b/lib/features/shell/presentation/pages/app_shell.dart
@@ -1,5 +1,6 @@
 import 'package:booking_group_flutter/features/home/presentation/pages/home_page.dart';
 import 'package:booking_group_flutter/features/ideas/presentation/pages/ideas_page.dart';
+import 'package:booking_group_flutter/features/notifications/application/notification_controller.dart';
 import 'package:booking_group_flutter/features/notifications/presentation/pages/notification_page.dart';
 import 'package:booking_group_flutter/features/profile/presentation/pages/profile_page.dart';
 import 'package:booking_group_flutter/features/shell/presentation/widgets/rounded_bottom_navigation.dart';
@@ -16,17 +17,13 @@ class _AppShellState extends State<AppShell> {
   int _currentIndex = 0;
 
   late final List<Widget> _pages;
-
-  final List<IconData> _icons = const [
-    Icons.home_outlined,
-    Icons.star_outline, // Icon ngôi sao cho Ideas
-    Icons.notifications_none,
-    Icons.person_outline,
-  ];
+  late final NotificationController _notificationController;
 
   @override
   void initState() {
     super.initState();
+    _notificationController = NotificationController();
+    _notificationController.loadNotifications();
     _pages = [
       const HomePage(),
       IdeasPage(
@@ -37,6 +34,7 @@ class _AppShellState extends State<AppShell> {
         },
       ),
       NotificationPage(
+        controller: _notificationController,
         onBack: () {
           setState(() {
             _currentIndex = 0;
@@ -54,18 +52,55 @@ class _AppShellState extends State<AppShell> {
   }
 
   @override
+  void dispose() {
+    _notificationController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: IndexedStack(index: _currentIndex, children: _pages),
       bottomNavigationBar: Padding(
         padding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
-        child: RoundedBottomNavigation(
-          currentIndex: _currentIndex,
-          items: _icons,
-          onItemSelected: (index) {
-            setState(() {
-              _currentIndex = index;
-            });
+        child: AnimatedBuilder(
+          animation: _notificationController,
+          builder: (context, _) {
+            final unreadCount = _notificationController.unreadCount;
+            final navItems = [
+              const RoundedNavItem(icon: Icons.home_outlined),
+              const RoundedNavItem(icon: Icons.star_outline),
+              RoundedNavItem(
+                icon: unreadCount > 0
+                    ? Icons.notifications
+                    : Icons.notifications_none,
+                badgeCount: unreadCount,
+              ),
+              const RoundedNavItem(icon: Icons.person_outline),
+            ];
+
+            return RoundedBottomNavigation(
+              currentIndex: _currentIndex,
+              items: navItems,
+              onItemSelected: (index) {
+                setState(() {
+                  _currentIndex = index;
+                });
+
+                if (index == 2) {
+                  _notificationController
+                      .markAllAsRead()
+                      .catchError((error) {
+                    if (!mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Không thể cập nhật thông báo: $error'),
+                      ),
+                    );
+                  });
+                }
+              },
+            );
           },
         ),
       ),

--- a/lib/features/shell/presentation/widgets/rounded_bottom_navigation.dart
+++ b/lib/features/shell/presentation/widgets/rounded_bottom_navigation.dart
@@ -11,7 +11,7 @@ class RoundedBottomNavigation extends StatelessWidget {
 
   final int currentIndex;
   final ValueChanged<int> onItemSelected;
-  final List<IconData> items;
+  final List<RoundedNavItem> items;
 
   @override
   Widget build(BuildContext context) {
@@ -34,6 +34,7 @@ class RoundedBottomNavigation extends StatelessWidget {
         children: List.generate(
           items.length,
           (index) {
+            final item = items[index];
             final isSelected = index == currentIndex;
             return GestureDetector(
               onTap: () => onItemSelected(index),
@@ -46,12 +47,41 @@ class RoundedBottomNavigation extends StatelessWidget {
                       : Colors.transparent,
                   borderRadius: BorderRadius.circular(20),
                 ),
-                child: Icon(
-                  items[index],
-                  color: isSelected
-                      ? Colors.white
-                      : const Color.fromRGBO(255, 255, 255, 0.7),
-                  size: 24,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Icon(
+                      item.icon,
+                      color: isSelected
+                          ? Colors.white
+                          : const Color.fromRGBO(255, 255, 255, 0.7),
+                      size: 24,
+                    ),
+                    if (item.badgeCount > 0)
+                      Positioned(
+                        top: -2,
+                        right: -6,
+                        child: Container(
+                          padding:
+                              const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFE53935),
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(color: Colors.white, width: 1),
+                          ),
+                          constraints: const BoxConstraints(minWidth: 18),
+                          child: Text(
+                            item.badgeLabel,
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 10,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
                 ),
               ),
             );
@@ -60,4 +90,16 @@ class RoundedBottomNavigation extends StatelessWidget {
       ),
     );
   }
+}
+
+class RoundedNavItem {
+  const RoundedNavItem({
+    required this.icon,
+    this.badgeCount = 0,
+  });
+
+  final IconData icon;
+  final int badgeCount;
+
+  String get badgeLabel => badgeCount > 99 ? '99+' : '$badgeCount';
 }

--- a/lib/models/app_notification.dart
+++ b/lib/models/app_notification.dart
@@ -1,0 +1,169 @@
+class AppNotification {
+  const AppNotification({
+    required this.id,
+    required this.title,
+    required this.message,
+    required this.isRead,
+    this.createdAt,
+  });
+
+  final int id;
+  final String title;
+  final String message;
+  final bool isRead;
+  final DateTime? createdAt;
+
+  bool get isUnread => !isRead;
+
+  factory AppNotification.fromJson(Map<String, dynamic> json) {
+    final id = _parseId(json);
+    final title = _parseTitle(json);
+    final message = _parseMessage(json);
+    final createdAt = _parseDate(json['createdAt'] ?? json['created_at']);
+    final isRead = _parseReadStatus(json);
+
+    return AppNotification(
+      id: id,
+      title: title,
+      message: message,
+      isRead: isRead,
+      createdAt: createdAt,
+    );
+  }
+
+  AppNotification copyWith({
+    int? id,
+    String? title,
+    String? message,
+    bool? isRead,
+    DateTime? createdAt,
+  }) {
+    return AppNotification(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      message: message ?? this.message,
+      isRead: isRead ?? this.isRead,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(id, title, message, isRead, createdAt);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is AppNotification &&
+        other.id == id &&
+        other.title == title &&
+        other.message == message &&
+        other.isRead == isRead &&
+        other.createdAt == createdAt;
+  }
+}
+
+int _parseId(Map<String, dynamic> json) {
+  final rawId = json['id'] ?? json['notificationId'] ?? json['notification_id'];
+  if (rawId is int) return rawId;
+  if (rawId is num) return rawId.toInt();
+  if (rawId is String) {
+    return int.tryParse(rawId) ?? rawId.hashCode;
+  }
+  return DateTime.now().millisecondsSinceEpoch;
+}
+
+String _parseTitle(Map<String, dynamic> json) {
+  final candidates = [
+    json['title'],
+    json['subject'],
+    json['type'],
+  ];
+
+  for (final candidate in candidates) {
+    if (candidate is String && candidate.trim().isNotEmpty) {
+      return candidate.trim();
+    }
+  }
+
+  return 'Notification';
+}
+
+String _parseMessage(Map<String, dynamic> json) {
+  final candidates = [
+    json['message'],
+    json['content'],
+    json['body'],
+    json['description'],
+  ];
+
+  for (final candidate in candidates) {
+    if (candidate is String && candidate.trim().isNotEmpty) {
+      return candidate.trim();
+    }
+  }
+
+  return '';
+}
+
+DateTime? _parseDate(dynamic value) {
+  if (value == null) return null;
+  if (value is DateTime) return value;
+  if (value is int) {
+    return DateTime.fromMillisecondsSinceEpoch(value);
+  }
+  if (value is String && value.isNotEmpty) {
+    try {
+      return DateTime.parse(value);
+    } catch (_) {
+      return null;
+    }
+  }
+  return null;
+}
+
+bool _parseReadStatus(Map<String, dynamic> json) {
+  final rawIsRead = json['isRead'] ?? json['read'] ?? json['seen'];
+  if (rawIsRead is bool) {
+    return rawIsRead;
+  }
+  if (rawIsRead is num) {
+    return rawIsRead != 0;
+  }
+  if (rawIsRead is String) {
+    final normalized = rawIsRead.toLowerCase();
+    if (normalized == 'true' || normalized == 'read' || normalized == 'seen') {
+      return true;
+    }
+    if (normalized == 'false' || normalized == 'unread') {
+      return false;
+    }
+  }
+
+  final status = json['status'];
+  if (status is String) {
+    final normalized = status.toUpperCase();
+    if (normalized == 'UNREAD' || normalized == 'NEW') {
+      return false;
+    }
+    if (normalized == 'READ' || normalized == 'DONE') {
+      return true;
+    }
+  }
+  if (status is num) {
+    // Some backends encode unread notifications with 200/201 codes.
+    if (status == 200 || status == 201) {
+      return false;
+    }
+    if (status == 204 || status == 205) {
+      return true;
+    }
+  }
+
+  final readAt = json['readAt'] ?? json['read_at'];
+  if (readAt != null) {
+    return true;
+  }
+
+  return false;
+}

--- a/lib/models/major.dart
+++ b/lib/models/major.dart
@@ -6,14 +6,53 @@ class Major {
   Major({this.id, required this.name, this.active = true});
 
   factory Major.fromJson(Map<String, dynamic> json) {
+    final resolvedName = _readName(json);
+    final resolvedId = _readId(json);
+    final resolvedActive = _readActive(json);
+
     return Major(
-      id: json['id'] as int?,
-      name: json['name'] as String? ?? '',
-      active: json['active'] as bool? ?? true,
+      id: resolvedId,
+      name: resolvedName,
+      active: resolvedActive,
     );
   }
 
   Map<String, dynamic> toJson() {
     return {'id': id, 'name': name, 'active': active};
   }
+}
+
+int? _readId(Map<String, dynamic> json) {
+  final rawId = json['id'] ?? json['majorId'] ?? json['major_id'];
+  if (rawId is int) return rawId;
+  if (rawId is num) return rawId.toInt();
+  if (rawId is String) {
+    return int.tryParse(rawId);
+  }
+  return null;
+}
+
+String _readName(Map<String, dynamic> json) {
+  final rawName =
+      json['name'] ?? json['majorName'] ?? json['major_name'] ?? json['title'];
+  if (rawName is String && rawName.trim().isNotEmpty) {
+    return rawName.trim();
+  }
+  return '';
+}
+
+bool _readActive(Map<String, dynamic> json) {
+  final rawActive = json['active'] ?? json['isActive'] ?? json['status'];
+  if (rawActive is bool) return rawActive;
+  if (rawActive is num) return rawActive != 0;
+  if (rawActive is String) {
+    final normalized = rawActive.toLowerCase();
+    if (normalized == 'true' || normalized == 'active' || normalized == '1') {
+      return true;
+    }
+    if (normalized == 'false' || normalized == 'inactive' || normalized == '0') {
+      return false;
+    }
+  }
+  return true;
 }

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -28,7 +28,7 @@ class UserProfile {
       email: json['email'] as String? ?? '',
       cwu: json['cwu'] as String?,
       avatarUrl: _extractAvatarUrl(json['avatarUrl']),
-      major: json['major'] != null ? Major.fromJson(json['major']) : null,
+      major: _resolveMajor(json),
       role: json['role'] as String? ?? 'STUDENT',
       isActive: json['isActive'] as bool? ?? true,
     );
@@ -85,6 +85,34 @@ String? _extractAvatarUrl(dynamic avatar) {
         return candidate;
       }
     }
+  }
+
+  return null;
+}
+
+Major? _resolveMajor(Map<String, dynamic> json) {
+  final dynamic majorData = json['major'];
+  if (majorData is Map<String, dynamic>) {
+    return Major.fromJson(majorData);
+  }
+
+  if (majorData is String && majorData.trim().isNotEmpty) {
+    return Major(name: majorData.trim());
+  }
+
+  final fallbackName = json['majorName'] ?? json['major_name'];
+  final fallbackId = json['majorId'] ?? json['major_id'];
+  if (fallbackName is String && fallbackName.trim().isNotEmpty) {
+    return Major(
+      id: fallbackId is int
+          ? fallbackId
+          : fallbackId is num
+              ? fallbackId.toInt()
+              : fallbackId is String
+                  ? int.tryParse(fallbackId)
+                  : null,
+      name: fallbackName.trim(),
+    );
   }
 
   return null;

--- a/lib/resources/notifications_api.dart
+++ b/lib/resources/notifications_api.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+
+import 'package:booking_group_flutter/core/constants/api_constants.dart';
+import 'package:booking_group_flutter/models/app_notification.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class NotificationsApi {
+  Future<String?> _getBearerToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('bearerToken');
+  }
+
+  Future<List<AppNotification>> fetchNotifications() async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('Missing authentication token');
+    }
+
+    final response = await http.get(
+      Uri.parse(ApiConstants.notificationsUrl),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load notifications (${response.statusCode})');
+    }
+
+    final Map<String, dynamic> jsonResponse = json.decode(response.body);
+    final dynamic data = jsonResponse['data'];
+
+    final Iterable items;
+    if (data is List) {
+      items = data;
+    } else if (data is Map<String, dynamic>) {
+      final content = data['content'];
+      if (content is List) {
+        items = content;
+      } else {
+        items = const [];
+      }
+    } else {
+      items = const [];
+    }
+
+    return items
+        .whereType<Map<String, dynamic>>()
+        .map(AppNotification.fromJson)
+        .toList()
+      ..sort((a, b) {
+        final aTime = a.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+        final bTime = b.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+        return bTime.compareTo(aTime);
+      });
+  }
+
+  Future<AppNotification> markAsRead(int notificationId) async {
+    final token = await _getBearerToken();
+    if (token == null) {
+      throw Exception('Missing authentication token');
+    }
+
+    final response = await http.patch(
+      Uri.parse(ApiConstants.markNotificationAsReadUrl(notificationId)),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Failed to mark notification as read (${response.statusCode})',
+      );
+    }
+
+    final Map<String, dynamic> jsonResponse = json.decode(response.body);
+    final data = jsonResponse['data'];
+    if (data is Map<String, dynamic>) {
+      return AppNotification.fromJson(data);
+    }
+
+    return AppNotification(
+      id: notificationId,
+      title: 'Notification',
+      message: '',
+      isRead: true,
+      createdAt: null,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- point the profile screen at the stored `bearerToken` so backend data (including the major name) loads correctly and clear it on logout
- pull both the current group and pending join requests on the home page so we can surface the newest pending group request when the user has no group
- extend the Your Request home card to show a highlighted tile with the last requested group, status, and time for groupless users

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6901546a6fbc832fb890839fdfb5554c