### PR TITLE
Add group chat tab and in-group chat popup

### DIFF
--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -112,6 +112,44 @@ class ApiConstants {
     return '$baseApiUrl$ideas/group/$groupId';
   }
 
+  // Chat Endpoints
+  static const String chat = '/chat';
+  static String get chatBaseUrl => '$baseApiUrl$chat';
+
+  static String getGroupChatMessagesUrl(
+    int groupId, {
+    int page = 1,
+    int size = 50,
+  }) {
+    return '$chatBaseUrl/groups/$groupId/messages?page=$page&size=$size';
+  }
+
+  static String createChatMessageUrl() {
+    return '$chatBaseUrl/messages';
+  }
+
+  static String updateChatMessageUrl(int messageId) {
+    return '$chatBaseUrl/messages/$messageId';
+  }
+
+  static String deleteChatMessageUrl(int messageId) {
+    return '$chatBaseUrl/messages/$messageId';
+  }
+
+  static String getChatMessageDetailUrl(int messageId) {
+    return '$chatBaseUrl/messages/$messageId';
+  }
+
+  static String searchGroupChatMessagesUrl(
+    int groupId,
+    String keyword, {
+    int page = 1,
+    int size = 50,
+  }) {
+    final encodedKeyword = Uri.encodeQueryComponent(keyword);
+    return '$chatBaseUrl/groups/$groupId/search?keyword=$encodedKeyword&page=$page&size=$size';
+  }
+
   static String getIdeaUrl(int ideaId) {
     return '$baseApiUrl$ideas/$ideaId';
   }

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -1,5 +1,4 @@
 import 'package:booking_group_flutter/core/services/api_service.dart';
-import 'package:booking_group_flutter/features/auth/presentation/pages/signup_page.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
@@ -13,31 +12,7 @@ class LoginPage extends StatefulWidget {
 }
 
 class _LoginPageState extends State<LoginPage> {
-  final emailController = TextEditingController();
-  final passwordController = TextEditingController();
-  final formKey = GlobalKey<FormState>();
   final ApiService _apiService = ApiService();
-
-  @override
-  void dispose() {
-    emailController.dispose();
-    passwordController.dispose();
-    super.dispose();
-  }
-
-  Future<void> logInWithEmailAndPassword() async {
-    // Implement sign-in logic here
-    try {
-      final userCredential = await FirebaseAuth.instance
-          .signInWithEmailAndPassword(
-            email: emailController.text.trim(),
-            password: passwordController.text.trim(),
-          );
-      print(userCredential);
-    } on FirebaseAuthException catch (e) {
-      print(e.message);
-    }
-  }
 
   Future<void> signInWithGoogle() async {
     try {
@@ -135,110 +110,133 @@ class _LoginPageState extends State<LoginPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(),
-      body: Padding(
-        padding: const EdgeInsets.all(15.0),
-        child: Form(
-          key: formKey,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Text(
-                'Sign In.',
-                style: TextStyle(fontSize: 50, fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 30),
-              TextFormField(
-                controller: emailController,
-                decoration: const InputDecoration(hintText: 'Email'),
-              ),
-              const SizedBox(height: 15),
-              TextFormField(
-                controller: passwordController,
-                decoration: const InputDecoration(hintText: 'Password'),
-                obscureText: true,
-              ),
-              const SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: () async {
-                  await logInWithEmailAndPassword();
-                },
-                child: const Text(
-                  'SIGN IN',
-                  style: TextStyle(fontSize: 16, color: Colors.white),
-                ),
-              ),
-              const SizedBox(height: 15),
-              const Row(
-                children: [
-                  Expanded(child: Divider()),
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 16),
-                    child: Text('OR'),
-                  ),
-                  Expanded(child: Divider()),
-                ],
-              ),
-              const SizedBox(height: 15),
-              SizedBox(
-                width: double.infinity,
-                height: 60,
-                child: OutlinedButton(
-                  onPressed: () async {
-                    await signInWithGoogle();
-                  },
-                  style: OutlinedButton.styleFrom(
-                    backgroundColor: Colors.white,
-                    side: BorderSide(color: Colors.grey.shade300, width: 2),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(15),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF222B45), Color(0xFF151824)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: Container(
+                padding: const EdgeInsets.all(28),
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(0.95),
+                  borderRadius: BorderRadius.circular(24),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.15),
+                      blurRadius: 30,
+                      offset: const Offset(0, 20),
                     ),
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      SizedBox(
-                        height: 24,
-                        width: 24,
-                        child: Image.network(
-                          'https://developers.google.com/identity/images/g-logo.png',
-                          fit: BoxFit.contain,
-                          errorBuilder: (context, error, stackTrace) {
-                            return const Icon(Icons.account_circle, size: 24);
-                          },
+                  ],
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Container(
+                      height: 64,
+                      width: 64,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        gradient: const LinearGradient(
+                          colors: [Color(0xFF4A90E2), Color(0xFF007AFF)],
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.blueAccent.withOpacity(0.35),
+                            blurRadius: 18,
+                            offset: const Offset(0, 6),
+                          ),
+                        ],
+                      ),
+                      child: const Icon(
+                        Icons.group_work_rounded,
+                        color: Colors.white,
+                        size: 34,
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    Text(
+                      'Welcome back',
+                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: const Color(0xFF121212),
+                          ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Đăng nhập để tiếp tục quản lý nhóm học tập của bạn.',
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Colors.grey.shade600,
+                          ),
+                    ),
+                    const SizedBox(height: 32),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 58,
+                      child: OutlinedButton(
+                        onPressed: () async {
+                          await signInWithGoogle();
+                        },
+                        style: OutlinedButton.styleFrom(
+                          backgroundColor: Colors.white,
+                          side:
+                              BorderSide(color: Colors.grey.shade200, width: 1),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          elevation: 2,
+                          shadowColor: Colors.black.withOpacity(0.1),
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SizedBox(
+                              height: 26,
+                              width: 26,
+                              child: Image.network(
+                                'https://developers.google.com/identity/images/g-logo.png',
+                                fit: BoxFit.contain,
+                                errorBuilder: (context, error, stackTrace) {
+                                  return const Icon(Icons.account_circle,
+                                      size: 26, color: Colors.black54);
+                                },
+                              ),
+                            ),
+                            const SizedBox(width: 14),
+                            const Text(
+                              'Sign in with Google',
+                              style: TextStyle(
+                                fontSize: 16,
+                                color: Colors.black,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
-                      const SizedBox(width: 12),
-                      const Text(
-                        'Sign in with Google',
-                        style: TextStyle(fontSize: 16, color: Colors.black),
-                      ),
-                    ],
-                  ),
+                    ),
+                    const SizedBox(height: 18),
+                    Text(
+                      'Powered by Booking Group Flutter',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Colors.grey.shade500,
+                            letterSpacing: 0.5,
+                          ),
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(height: 20),
-              GestureDetector(
-                onTap: () {
-                  Navigator.push(context, SignUpPage.route());
-                },
-                child: RichText(
-                  text: TextSpan(
-                    text: 'Don\'t have an account? ',
-                    style: Theme.of(context).textTheme.titleMedium,
-                    children: [
-                      TextSpan(
-                        text: 'Sign Up',
-                        style: Theme.of(context).textTheme.titleMedium
-                            ?.copyWith(fontWeight: FontWeight.bold),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/features/chat/application/chat_controller.dart
+++ b/lib/features/chat/application/chat_controller.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+
+import 'package:booking_group_flutter/models/chat_message.dart';
+import 'package:booking_group_flutter/resources/chat_api.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+
+/// Controller that manages chat state, polling and mutations.
+class ChatController extends ChangeNotifier {
+  ChatController({required this.groupId});
+
+  final int groupId;
+  final ChatApi _chatApi = ChatApi();
+  Timer? _pollingTimer;
+
+  List<ChatMessage> _messages = const [];
+  bool _isLoading = false;
+  bool _isRefreshing = false;
+  bool _isSending = false;
+  bool _isUpdating = false;
+  bool _isDeleting = false;
+  String? _errorMessage;
+  String? _currentUserEmail;
+
+  List<ChatMessage> get messages => List.unmodifiable(_messages);
+  bool get isLoading => _isLoading;
+  bool get isRefreshing => _isRefreshing;
+  bool get isSending => _isSending;
+  bool get isUpdating => _isUpdating;
+  bool get isDeleting => _isDeleting;
+  bool get isMutating => _isSending || _isUpdating || _isDeleting;
+  String? get errorMessage => _errorMessage;
+  String? get currentUserEmail => _currentUserEmail;
+
+  /// Initializes the controller by loading the first page and starting polling.
+  Future<void> initialize() async {
+    _currentUserEmail = FirebaseAuth.instance.currentUser?.email?.toLowerCase();
+    await refreshMessages(showLoading: true);
+    _startPolling();
+  }
+
+  Future<void> refreshMessages({bool showLoading = false}) async {
+    if (_isLoading || _isRefreshing) {
+      return;
+    }
+
+    if (showLoading) {
+      _isLoading = true;
+    } else {
+      _isRefreshing = true;
+    }
+    notifyListeners();
+
+    try {
+      final fetched = await _chatApi.getGroupMessages(groupId);
+      fetched.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      _messages = fetched;
+      _errorMessage = null;
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      if (showLoading) {
+        _isLoading = false;
+      } else {
+        _isRefreshing = false;
+      }
+      notifyListeners();
+    }
+  }
+
+  Future<void> sendMessage(
+    String content, {
+    int? replyToMessageId,
+  }) async {
+    final trimmed = content.trim();
+    if (trimmed.isEmpty || _isSending) {
+      return;
+    }
+
+    _isSending = true;
+    notifyListeners();
+
+    try {
+      await _chatApi.sendMessage(
+        groupId: groupId,
+        content: trimmed,
+        replyToMessageId: replyToMessageId,
+      );
+      await refreshMessages();
+    } catch (error) {
+      _errorMessage = error.toString();
+      rethrow;
+    } finally {
+      _isSending = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> updateMessage(int messageId, String content) async {
+    final trimmed = content.trim();
+    if (messageId <= 0 || trimmed.isEmpty || _isUpdating) {
+      return;
+    }
+
+    _isUpdating = true;
+    notifyListeners();
+
+    try {
+      await _chatApi.updateMessage(
+        messageId: messageId,
+        content: trimmed,
+      );
+      await refreshMessages();
+    } catch (error) {
+      _errorMessage = error.toString();
+      rethrow;
+    } finally {
+      _isUpdating = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> deleteMessage(int messageId) async {
+    if (messageId <= 0 || _isDeleting) {
+      return;
+    }
+
+    _isDeleting = true;
+    notifyListeners();
+
+    try {
+      await _chatApi.deleteMessage(messageId);
+      await refreshMessages();
+    } catch (error) {
+      _errorMessage = error.toString();
+      rethrow;
+    } finally {
+      _isDeleting = false;
+      notifyListeners();
+    }
+  }
+
+  Future<List<ChatMessage>> searchMessages(String keyword) async {
+    try {
+      return await _chatApi.searchMessages(
+        groupId: groupId,
+        keyword: keyword,
+      );
+    } catch (error) {
+      _errorMessage = error.toString();
+      rethrow;
+    }
+  }
+
+  void _startPolling() {
+    _pollingTimer?.cancel();
+    _pollingTimer = Timer.periodic(const Duration(seconds: 5), (_) {
+      refreshMessages();
+    });
+  }
+
+  void stopPolling() {
+    _pollingTimer?.cancel();
+    _pollingTimer = null;
+  }
+
+  @override
+  void dispose() {
+    stopPolling();
+    super.dispose();
+  }
+}

--- a/lib/features/chat/presentation/pages/chat_page.dart
+++ b/lib/features/chat/presentation/pages/chat_page.dart
@@ -73,51 +73,54 @@ class _ChatPageState extends State<ChatPage> {
 
   Widget _buildBody(MyGroup? group) {
     if (_errorMessage != null) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(Icons.error_outline, size: 48, color: Colors.redAccent),
-              const SizedBox(height: 16),
-              Text(
-                _errorMessage!,
-                textAlign: TextAlign.center,
-                style: const TextStyle(color: Colors.redAccent),
-              ),
-              const SizedBox(height: 16),
-              ElevatedButton.icon(
-                onPressed: _loadGroup,
-                icon: const Icon(Icons.refresh),
-                label: const Text('Thử lại'),
-              ),
-            ],
-          ),
-        ),
-      );
+      return _JoinGroupNotice(onRetry: _loadGroup);
     }
 
     if (group == null) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: const [
-              Icon(Icons.forum_outlined, size: 64, color: Color(0xFF8B5CF6)),
-              SizedBox(height: 16),
-              Text(
-                'Bạn cần tham gia một nhóm trước khi có thể sử dụng chat.',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 16),
-              ),
-            ],
-          ),
-        ),
-      );
+      return const _JoinGroupNotice();
     }
 
     return ChatView(groupId: group.id);
+  }
+}
+
+class _JoinGroupNotice extends StatelessWidget {
+  const _JoinGroupNotice({this.onRetry});
+
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.forum_outlined, size: 64, color: Color(0xFF8B5CF6)),
+            const SizedBox(height: 16),
+            const Text(
+              'Bạn cần tham gia một nhóm trước khi có thể sử dụng chat.',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 16),
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 20),
+              OutlinedButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Thử lại'),
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/chat/presentation/pages/chat_page.dart
+++ b/lib/features/chat/presentation/pages/chat_page.dart
@@ -1,0 +1,123 @@
+import 'package:booking_group_flutter/features/chat/presentation/widgets/chat_view.dart';
+import 'package:booking_group_flutter/models/my_group.dart';
+import 'package:booking_group_flutter/resources/my_group_api.dart';
+import 'package:flutter/material.dart';
+
+class ChatPage extends StatefulWidget {
+  const ChatPage({super.key});
+
+  @override
+  State<ChatPage> createState() => _ChatPageState();
+}
+
+class _ChatPageState extends State<ChatPage> {
+  final MyGroupApi _myGroupApi = MyGroupApi();
+
+  MyGroup? _myGroup;
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadGroup();
+  }
+
+  Future<void> _loadGroup() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final group = await _myGroupApi.getMyGroup();
+      if (!mounted) return;
+      setState(() {
+        _myGroup = group;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _errorMessage = error.toString();
+      });
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final group = _myGroup;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Group Chat'),
+        backgroundColor: const Color(0xFF8B5CF6),
+        foregroundColor: Colors.white,
+        actions: [
+          IconButton(
+            onPressed: _isLoading ? null : _loadGroup,
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Làm mới nhóm',
+          ),
+        ],
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _buildBody(group),
+    );
+  }
+
+  Widget _buildBody(MyGroup? group) {
+    if (_errorMessage != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline, size: 48, color: Colors.redAccent),
+              const SizedBox(height: 16),
+              Text(
+                _errorMessage!,
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: Colors.redAccent),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton.icon(
+                onPressed: _loadGroup,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Thử lại'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (group == null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: const [
+              Icon(Icons.forum_outlined, size: 64, color: Color(0xFF8B5CF6)),
+              SizedBox(height: 16),
+              Text(
+                'Bạn cần tham gia một nhóm trước khi có thể sử dụng chat.',
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 16),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return ChatView(groupId: group.id);
+  }
+}

--- a/lib/features/chat/presentation/widgets/chat_message_bubble.dart
+++ b/lib/features/chat/presentation/widgets/chat_message_bubble.dart
@@ -1,0 +1,238 @@
+import 'package:booking_group_flutter/models/chat_message.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+typedef ChatMessageActionCallback = void Function(ChatMessage message);
+
+class ChatMessageBubble extends StatelessWidget {
+  const ChatMessageBubble({
+    super.key,
+    required this.message,
+    required this.isMine,
+    this.onReply,
+    this.onEdit,
+    this.onDelete,
+  });
+
+  final ChatMessage message;
+  final bool isMine;
+  final ChatMessageActionCallback? onReply;
+  final ChatMessageActionCallback? onEdit;
+  final ChatMessageActionCallback? onDelete;
+
+  Color get _bubbleColor => isMine
+      ? const Color(0xFF8B5CF6)
+      : const Color(0xFFF1F5F9);
+
+  Color get _textColor => isMine ? Colors.white : const Color(0xFF1F2937);
+
+  BorderRadius get _borderRadius => BorderRadius.only(
+        topLeft: const Radius.circular(18),
+        topRight: const Radius.circular(18),
+        bottomLeft: Radius.circular(isMine ? 18 : 6),
+        bottomRight: Radius.circular(isMine ? 6 : 18),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final timestamp = DateFormat('HH:mm').format(message.createdAt);
+    final actions = <PopupMenuEntry<_MessageAction>>[
+      PopupMenuItem(
+        value: _MessageAction.reply,
+        child: Row(
+          children: const [
+            Icon(Icons.reply, size: 18),
+            SizedBox(width: 8),
+            Text('Trả lời'),
+          ],
+        ),
+      ),
+      if (isMine)
+        PopupMenuItem(
+          value: _MessageAction.edit,
+          child: Row(
+            children: const [
+              Icon(Icons.edit, size: 18),
+              SizedBox(width: 8),
+              Text('Chỉnh sửa'),
+            ],
+          ),
+        ),
+      if (isMine)
+        PopupMenuItem(
+          value: _MessageAction.delete,
+          child: Row(
+            children: const [
+              Icon(Icons.delete_outline, size: 18),
+              SizedBox(width: 8),
+              Text('Xóa'),
+            ],
+          ),
+        ),
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment:
+            isMine ? MainAxisAlignment.end : MainAxisAlignment.start,
+        children: [
+          if (!isMine)
+            CircleAvatar(
+              radius: 16,
+              backgroundColor: const Color(0xFF8B5CF6).withValues(alpha: 0.2),
+              child: Text(
+                _initials(message.senderName),
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: Color(0xFF8B5CF6),
+                ),
+              ),
+            ),
+          if (!isMine) const SizedBox(width: 8),
+          Flexible(
+            child: Column(
+              crossAxisAlignment:
+                  isMine ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: isMine
+                      ? MainAxisAlignment.end
+                      : MainAxisAlignment.start,
+                  children: [
+                    Flexible(
+                      child: Text(
+                        message.senderName,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          color: isMine
+                              ? const Color.fromARGB(255, 230, 223, 255)
+                              : const Color(0xFF1F2937),
+                        ),
+                      ),
+                    ),
+                    PopupMenuButton<_MessageAction>(
+                      onSelected: (action) {
+                        switch (action) {
+                          case _MessageAction.reply:
+                            onReply?.call(message);
+                          case _MessageAction.edit:
+                            onEdit?.call(message);
+                          case _MessageAction.delete:
+                            onDelete?.call(message);
+                        }
+                      },
+                      icon: Icon(
+                        Icons.more_vert,
+                        size: 18,
+                        color: isMine
+                            ? const Color.fromARGB(255, 230, 223, 255)
+                            : Colors.black45,
+                      ),
+                      itemBuilder: (_) => actions,
+                    ),
+                  ],
+                ),
+                if (message.hasReply && message.replyToContent != null)
+                  Container(
+                    margin: const EdgeInsets.only(top: 6, bottom: 4),
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: isMine
+                          ? const Color.fromARGB(255, 108, 65, 193)
+                              .withValues(alpha: 0.4)
+                          : Colors.white,
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: const Color(0xFFCBD5F5),
+                        width: 1,
+                      ),
+                    ),
+                    child: Text(
+                      message.replyToContent!,
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: isMine
+                            ? const Color.fromARGB(255, 237, 235, 246)
+                            : const Color(0xFF475569),
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                  ),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  decoration: BoxDecoration(
+                    color: _bubbleColor,
+                    borderRadius: _borderRadius,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        message.content,
+                        style: TextStyle(
+                          color: _textColor,
+                          fontSize: 15,
+                          height: 1.3,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        _buildMeta(timestamp),
+                        style: TextStyle(
+                          color: _textColor.withValues(alpha: 0.7),
+                          fontSize: 11,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (isMine) const SizedBox(width: 8),
+          if (isMine)
+            CircleAvatar(
+              radius: 16,
+              backgroundColor: const Color(0xFF8B5CF6).withValues(alpha: 0.2),
+              child: Text(
+                _initials(message.senderName),
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: Color(0xFF8B5CF6),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _buildMeta(String timestamp) {
+    if (message.isEdited) {
+      return '$timestamp • Đã chỉnh sửa';
+    }
+    return timestamp;
+  }
+
+  String _initials(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return '?';
+    final segments = trimmed.split(RegExp(r'\s+'));
+    if (segments.length == 1) {
+      return segments.first.characters.first.toUpperCase();
+    }
+    final first = segments.first.characters.first.toUpperCase();
+    final last = segments.last.characters.first.toUpperCase();
+    return '$first$last';
+  }
+}
+
+enum _MessageAction { reply, edit, delete }

--- a/lib/features/chat/presentation/widgets/chat_message_bubble.dart
+++ b/lib/features/chat/presentation/widgets/chat_message_bubble.dart
@@ -256,6 +256,7 @@ class ChatMessageBubble extends StatelessWidget {
         ],
         ),
       ),
+    ),
     );
   }
 

--- a/lib/features/chat/presentation/widgets/chat_view.dart
+++ b/lib/features/chat/presentation/widgets/chat_view.dart
@@ -425,6 +425,7 @@ class _ChatViewState extends State<ChatView> {
     final isLoading = _controller.isLoading && messages.isEmpty;
     final errorMessage = _controller.errorMessage;
     final currentEmail = _controller.currentUserEmail;
+    final currentUserId = _controller.currentUserId;
     final isSearchActive =
         _isSearchVisible && _searchKeyword.trim().length >= 2;
     final displayMessages =
@@ -499,10 +500,14 @@ class _ChatViewState extends State<ChatView> {
                         }
 
                         final message = displayMessages[index];
-                        final senderEmail = message.senderEmail?.toLowerCase();
-                        final isMine = currentEmail != null &&
-                            senderEmail != null &&
-                            senderEmail == currentEmail;
+                        final senderEmail =
+                            message.senderEmail?.trim().toLowerCase();
+                        final isMine = (currentEmail != null &&
+                                senderEmail != null &&
+                                senderEmail == currentEmail) ||
+                            (currentUserId != null &&
+                                currentUserId > 0 &&
+                                message.senderId == currentUserId);
                         final isSelected =
                             _selectedMessageIds.contains(message.id);
                         return ChatMessageBubble(

--- a/lib/features/chat/presentation/widgets/chat_view.dart
+++ b/lib/features/chat/presentation/widgets/chat_view.dart
@@ -1,0 +1,375 @@
+import 'package:booking_group_flutter/features/chat/application/chat_controller.dart';
+import 'package:booking_group_flutter/features/chat/presentation/widgets/chat_message_bubble.dart';
+import 'package:booking_group_flutter/models/chat_message.dart';
+import 'package:flutter/material.dart';
+
+class ChatView extends StatefulWidget {
+  const ChatView({
+    super.key,
+    required this.groupId,
+    this.padding,
+  });
+
+  final int groupId;
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  State<ChatView> createState() => _ChatViewState();
+}
+
+class _ChatViewState extends State<ChatView> {
+  late final ChatController _controller;
+  final TextEditingController _textController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  final FocusNode _inputFocusNode = FocusNode();
+
+  ChatMessage? _replyTo;
+  ChatMessage? _editingMessage;
+  int _previousMessageCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ChatController(groupId: widget.groupId);
+    _controller.addListener(_handleControllerUpdate);
+    _controller.initialize();
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_handleControllerUpdate);
+    _controller.dispose();
+    _textController.dispose();
+    _scrollController.dispose();
+    _inputFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleControllerUpdate() {
+    final currentCount = _controller.messages.length;
+    if (currentCount > _previousMessageCount && mounted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
+    }
+    _previousMessageCount = currentCount;
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  Future<void> _scrollToBottom() async {
+    if (!_scrollController.hasClients) return;
+    await _scrollController.animateTo(
+      _scrollController.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 280),
+      curve: Curves.easeOutCubic,
+    );
+  }
+
+  Future<void> _handleSend() async {
+    final text = _textController.text.trim();
+    if (text.isEmpty || _controller.isMutating) return;
+
+    try {
+      if (_editingMessage != null) {
+        await _controller.updateMessage(_editingMessage!.id, text);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Đã cập nhật tin nhắn.')),
+          );
+        }
+      } else {
+        await _controller.sendMessage(
+          text,
+          replyToMessageId: _replyTo?.id,
+        );
+      }
+
+      if (!mounted) return;
+      setState(() {
+        _replyTo = null;
+        _editingMessage = null;
+        _textController.clear();
+      });
+      _inputFocusNode.requestFocus();
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    }
+  }
+
+  void _handleReply(ChatMessage message) {
+    setState(() {
+      _replyTo = message;
+      _editingMessage = null;
+    });
+    _inputFocusNode.requestFocus();
+  }
+
+  void _handleEdit(ChatMessage message) {
+    setState(() {
+      _editingMessage = message;
+      _replyTo = null;
+      _textController.text = message.content;
+    });
+    _textController.selection = TextSelection.fromPosition(
+      TextPosition(offset: _textController.text.length),
+    );
+    _inputFocusNode.requestFocus();
+  }
+
+  Future<void> _handleDelete(ChatMessage message) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Xóa tin nhắn'),
+        content: const Text('Bạn có chắc chắn muốn xóa tin nhắn này?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Hủy'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Xóa'),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldDelete != true) return;
+
+    try {
+      await _controller.deleteMessage(message.id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Đã xóa tin nhắn.')),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    }
+  }
+
+  Widget _buildReplyPreview(ChatMessage message) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFEEF2FF),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.reply, size: 18, color: Color(0xFF4C1D95)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Trả lời ${message.senderName}',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF312E81),
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  message.content,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(color: Color(0xFF4C1D95)),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.close, size: 18),
+            onPressed: () {
+              setState(() => _replyTo = null);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEditingBanner(ChatMessage message) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFDF2F8),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFDB2777).withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.edit, size: 18, color: Color(0xFFDB2777)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Đang chỉnh sửa tin nhắn: "${message.content}"',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Color(0xFF9D174D)),
+            ),
+          ),
+          IconButton(
+            onPressed: () {
+              setState(() => _editingMessage = null);
+              _textController.clear();
+            },
+            icon: const Icon(Icons.close, size: 18),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final padding = widget.padding ?? const EdgeInsets.all(16);
+    final messages = _controller.messages;
+    final isLoading = _controller.isLoading && messages.isEmpty;
+    final errorMessage = _controller.errorMessage;
+    final currentEmail = _controller.currentUserEmail;
+
+    return Padding(
+      padding: padding,
+      child: Column(
+        children: [
+          if (errorMessage != null && messages.isEmpty)
+            Container(
+              padding: const EdgeInsets.all(12),
+              margin: const EdgeInsets.only(bottom: 12),
+              decoration: BoxDecoration(
+                color: const Color(0xFFFFE4E6),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.error_outline, color: Color(0xFFB91C1C)),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      errorMessage,
+                      style: const TextStyle(color: Color(0xFFB91C1C)),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => _controller.refreshMessages(showLoading: true),
+                    child: const Text('Thử lại'),
+                  ),
+                ],
+              ),
+            ),
+          Expanded(
+            child: isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : RefreshIndicator(
+                    onRefresh: () => _controller.refreshMessages(),
+                    child: ListView.builder(
+                      controller: _scrollController,
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      itemCount: messages.isEmpty ? 1 : messages.length,
+                      itemBuilder: (context, index) {
+                        if (messages.isEmpty) {
+                          return const Center(
+                            child: Padding(
+                              padding: EdgeInsets.symmetric(vertical: 48),
+                              child: Text(
+                                'Chưa có tin nhắn nào. Hãy bắt đầu cuộc trò chuyện!',
+                                style: TextStyle(color: Color(0xFF64748B)),
+                              ),
+                            ),
+                          );
+                        }
+
+                        final message = messages[index];
+                        final senderEmail = message.senderEmail?.toLowerCase();
+                        final isMine = currentEmail != null &&
+                            senderEmail != null &&
+                            senderEmail == currentEmail;
+                        return ChatMessageBubble(
+                          message: message,
+                          isMine: isMine,
+                          onReply: _handleReply,
+                          onEdit: isMine ? _handleEdit : null,
+                          onDelete: isMine ? _handleDelete : null,
+                        );
+                      },
+                    ),
+                  ),
+          ),
+          const SizedBox(height: 12),
+          if (_replyTo != null) _buildReplyPreview(_replyTo!),
+          if (_editingMessage != null) _buildEditingBanner(_editingMessage!),
+          _buildInputArea(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInputArea() {
+    final isBusy = _controller.isMutating;
+
+    return SafeArea(
+      top: false,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _textController,
+              focusNode: _inputFocusNode,
+              textInputAction: TextInputAction.newline,
+              minLines: 1,
+              maxLines: 5,
+              decoration: InputDecoration(
+                hintText: _editingMessage != null
+                    ? 'Chỉnh sửa tin nhắn...'
+                    : 'Nhập tin nhắn...',
+                filled: true,
+                fillColor: const Color(0xFFF8FAFC),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(20),
+                  borderSide: BorderSide.none,
+                ),
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 12,
+                ),
+              ),
+              onSubmitted: (_) => _handleSend(),
+            ),
+          ),
+          const SizedBox(width: 12),
+          DecoratedBox(
+            decoration: const BoxDecoration(
+              color: Color(0xFF8B5CF6),
+              shape: BoxShape.circle,
+            ),
+            child: IconButton(
+              onPressed: isBusy ? null : _handleSend,
+              icon: isBusy
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                      ),
+                    )
+                  : const Icon(Icons.send, color: Colors.white),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/my_group/presentation/pages/my_group_detail_page.dart
+++ b/lib/features/my_group/presentation/pages/my_group_detail_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:booking_group_flutter/features/chat/presentation/widgets/chat_view.dart';
 import 'package:booking_group_flutter/features/groups/presentation/pages/groups_list_page.dart';
 import 'package:booking_group_flutter/features/my_group/presentation/pages/group_ideas_page.dart';
 import 'package:booking_group_flutter/features/forum/presentation/widgets/forum_comment_profile_sheet.dart';
@@ -264,6 +265,8 @@ class _MyGroupDetailPageState extends State<MyGroupDetailPage> {
           const SizedBox(height: 24),
           _buildIdeasCard(),
           const SizedBox(height: 24),
+          _buildChatAccessCard(),
+          const SizedBox(height: 24),
           _buildVotePanel(),
           if (_isLeader) ...[
             const SizedBox(height: 24),
@@ -280,6 +283,117 @@ class _MyGroupDetailPageState extends State<MyGroupDetailPage> {
           ],
         ],
       ),
+    );
+  }
+
+  Widget _buildChatAccessCard() {
+    final group = _myGroup;
+    if (group == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Card(
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: InkWell(
+        onTap: _isBusy ? null : () => _openChatPopup(group.id),
+        borderRadius: BorderRadius.circular(16),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF6366F1).withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: const Icon(
+                  Icons.chat_bubble_outline,
+                  color: Color(0xFF6366F1),
+                  size: 32,
+                ),
+              ),
+              const SizedBox(width: 16),
+              const Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Group chat',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    SizedBox(height: 4),
+                    Text(
+                      'Trao đổi nhanh với các thành viên trong nhóm.',
+                      style: TextStyle(color: Colors.grey, fontSize: 14),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(Icons.open_in_new, color: Colors.grey, size: 20),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openChatPopup(int groupId) async {
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) {
+        return FractionallySizedBox(
+          heightFactor: 0.9,
+          child: ClipRRect(
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+            child: Material(
+              color: Colors.white,
+              child: SafeArea(
+                top: false,
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    bottom: MediaQuery.of(context).viewInsets.bottom,
+                  ),
+                  child: Column(
+                    children: [
+                      Container(
+                        width: 60,
+                        height: 5,
+                        margin: const EdgeInsets.only(top: 12, bottom: 12),
+                        decoration: BoxDecoration(
+                          color: Colors.grey.shade300,
+                          borderRadius: BorderRadius.circular(24),
+                        ),
+                      ),
+                      const Text(
+                        'Group chat',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      const Divider(height: 1),
+                      Expanded(
+                        child: ChatView(
+                          groupId: groupId,
+                          padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/features/shell/presentation/pages/app_shell.dart
+++ b/lib/features/shell/presentation/pages/app_shell.dart
@@ -1,3 +1,4 @@
+import 'package:booking_group_flutter/features/chat/presentation/pages/chat_page.dart';
 import 'package:booking_group_flutter/features/home/presentation/pages/home_page.dart';
 import 'package:booking_group_flutter/features/notifications/application/notification_controller.dart';
 import 'package:booking_group_flutter/features/notifications/presentation/pages/notification_page.dart';
@@ -26,6 +27,7 @@ class _AppShellState extends State<AppShell> {
     _pageController = PageController(initialPage: _currentIndex);
     _pages = [
       const HomePage(),
+      const ChatPage(),
       NotificationPage(controller: _notificationController),
       const ProfilePage(),
     ];
@@ -63,7 +65,7 @@ class _AppShellState extends State<AppShell> {
               _currentIndex = index;
             });
           }
-          if (index == 1) {
+          if (index == 2) {
             _refreshNotifications();
           }
         },
@@ -77,6 +79,7 @@ class _AppShellState extends State<AppShell> {
             final unreadCount = _notificationController.unreadCount;
             final navItems = [
               const RoundedNavItem(icon: Icons.home_outlined),
+              const RoundedNavItem(icon: Icons.chat_bubble_outline),
               RoundedNavItem(
                 icon: unreadCount > 0
                     ? Icons.notifications
@@ -94,7 +97,7 @@ class _AppShellState extends State<AppShell> {
                 setState(() {
                   _currentIndex = index;
                 });
-                if (index == 1) {
+                if (index == 2) {
                   _refreshNotifications();
                 }
                 _pageController.animateToPage(

--- a/lib/models/chat_message.dart
+++ b/lib/models/chat_message.dart
@@ -115,6 +115,47 @@ class ChatMessage {
       return null;
     }
 
+    int? resolveReplyId() {
+      final direct = _parseInt(json['replyToMessageId']);
+      if (direct != null && direct > 0) {
+        return direct;
+      }
+
+      final reply = json['reply'];
+      if (reply is Map<String, dynamic>) {
+        final nestedId = _parseInt(reply['replyToMessageId']) ??
+            _parseInt(reply['id']) ??
+            _parseInt(reply['messageId']);
+        if (nestedId != null && nestedId > 0) {
+          return nestedId;
+        }
+      }
+
+      return null;
+    }
+
+    String? resolveReplyContent() {
+      final direct = json['replyToContent'];
+      if (direct is String && direct.isNotEmpty) {
+        return direct;
+      }
+
+      final reply = json['reply'];
+      if (reply is Map<String, dynamic>) {
+        final nested = reply['replyToContent'];
+        if (nested is String && nested.isNotEmpty) {
+          return nested;
+        }
+
+        final content = reply['content'];
+        if (content is String && content.isNotEmpty) {
+          return content;
+        }
+      }
+
+      return null;
+    }
+
     return ChatMessage(
       id: _parseInt(json['id']) ?? 0,
       groupId: _parseInt(json['groupId']) ?? 0,
@@ -133,8 +174,8 @@ class ChatMessage {
       createdAt: parseDate(json['createdAt']) ?? DateTime.now(),
       updatedAt: parseDate(json['updatedAt']),
       isEdited: json['isEdited'] == true || json['edited'] == true,
-      replyToMessageId: _parseInt(json['replyToMessageId']),
-      replyToContent: json['replyToContent'] as String?,
+      replyToMessageId: resolveReplyId(),
+      replyToContent: resolveReplyContent(),
     );
   }
 

--- a/lib/models/chat_message.dart
+++ b/lib/models/chat_message.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/foundation.dart';
+
+/// Supported message types for the group chat experience.
+enum ChatMessageType { text, image, file }
+
+ChatMessageType _chatMessageTypeFromString(String? value) {
+  switch (value?.toUpperCase()) {
+    case 'IMAGE':
+      return ChatMessageType.image;
+    case 'FILE':
+      return ChatMessageType.file;
+    case 'TEXT':
+    default:
+      return ChatMessageType.text;
+  }
+}
+
+String chatMessageTypeToString(ChatMessageType type) {
+  switch (type) {
+    case ChatMessageType.image:
+      return 'IMAGE';
+    case ChatMessageType.file:
+      return 'FILE';
+    case ChatMessageType.text:
+      return 'TEXT';
+  }
+}
+
+/// Representation of a single message in a group chat.
+@immutable
+class ChatMessage {
+  const ChatMessage({
+    required this.id,
+    required this.groupId,
+    required this.senderId,
+    required this.senderName,
+    this.senderEmail,
+    required this.content,
+    required this.messageType,
+    required this.createdAt,
+    this.updatedAt,
+    this.isEdited = false,
+    this.replyToMessageId,
+    this.replyToContent,
+  });
+
+  final int id;
+  final int groupId;
+  final int senderId;
+  final String senderName;
+  final String? senderEmail;
+  final String content;
+  final ChatMessageType messageType;
+  final DateTime createdAt;
+  final DateTime? updatedAt;
+  final bool isEdited;
+  final int? replyToMessageId;
+  final String? replyToContent;
+
+  bool get hasReply => replyToMessageId != null && replyToMessageId! > 0;
+
+  bool get hasContent => content.trim().isNotEmpty;
+
+  ChatMessage copyWith({
+    int? id,
+    int? groupId,
+    int? senderId,
+    String? senderName,
+    String? senderEmail,
+    String? content,
+    ChatMessageType? messageType,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    bool? isEdited,
+    int? replyToMessageId,
+    String? replyToContent,
+  }) {
+    return ChatMessage(
+      id: id ?? this.id,
+      groupId: groupId ?? this.groupId,
+      senderId: senderId ?? this.senderId,
+      senderName: senderName ?? this.senderName,
+      senderEmail: senderEmail ?? this.senderEmail,
+      content: content ?? this.content,
+      messageType: messageType ?? this.messageType,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      isEdited: isEdited ?? this.isEdited,
+      replyToMessageId: replyToMessageId ?? this.replyToMessageId,
+      replyToContent: replyToContent ?? this.replyToContent,
+    );
+  }
+
+  factory ChatMessage.fromJson(Map<String, dynamic> json) {
+    DateTime? parseDate(dynamic value) {
+      if (value == null) return null;
+      if (value is DateTime) return value;
+      if (value is String && value.isNotEmpty) {
+        try {
+          return DateTime.parse(value).toLocal();
+        } catch (_) {
+          return null;
+        }
+      }
+      return null;
+    }
+
+    return ChatMessage(
+      id: (json['id'] as num?)?.toInt() ?? 0,
+      groupId: (json['groupId'] as num?)?.toInt() ?? 0,
+      senderId: (json['fromUserId'] as num?)?.toInt() ??
+          (json['senderId'] as num?)?.toInt() ??
+          0,
+      senderName: (json['fromUserName'] as String?) ??
+          (json['senderName'] as String?) ??
+          'Unknown',
+      senderEmail: (json['fromUserEmail'] as String?) ??
+          (json['senderEmail'] as String?),
+      content: (json['content'] as String?) ?? json['message'] as String? ?? '',
+      messageType: _chatMessageTypeFromString(
+        json['messageType'] as String? ?? json['type'] as String?,
+      ),
+      createdAt: parseDate(json['createdAt']) ?? DateTime.now(),
+      updatedAt: parseDate(json['updatedAt']),
+      isEdited: json['isEdited'] == true || json['edited'] == true,
+      replyToMessageId: (json['replyToMessageId'] as num?)?.toInt(),
+      replyToContent: json['replyToContent'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'groupId': groupId,
+        'fromUserId': senderId,
+        'fromUserName': senderName,
+        if (senderEmail != null) 'fromUserEmail': senderEmail,
+        'content': content,
+        'messageType': chatMessageTypeToString(messageType),
+        'createdAt': createdAt.toIso8601String(),
+        if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
+        'isEdited': isEdited,
+        if (replyToMessageId != null) 'replyToMessageId': replyToMessageId,
+        if (replyToContent != null) 'replyToContent': replyToContent,
+      };
+}

--- a/lib/models/chat_message.dart
+++ b/lib/models/chat_message.dart
@@ -26,6 +26,16 @@ String chatMessageTypeToString(ChatMessageType type) {
   }
 }
 
+int? _parseInt(dynamic value) {
+  if (value == null) return null;
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) {
+    return int.tryParse(value);
+  }
+  return null;
+}
+
 /// Representation of a single message in a group chat.
 @immutable
 class ChatMessage {
@@ -106,10 +116,10 @@ class ChatMessage {
     }
 
     return ChatMessage(
-      id: (json['id'] as num?)?.toInt() ?? 0,
-      groupId: (json['groupId'] as num?)?.toInt() ?? 0,
-      senderId: (json['fromUserId'] as num?)?.toInt() ??
-          (json['senderId'] as num?)?.toInt() ??
+      id: _parseInt(json['id']) ?? 0,
+      groupId: _parseInt(json['groupId']) ?? 0,
+      senderId: _parseInt(json['fromUserId']) ??
+          _parseInt(json['senderId']) ??
           0,
       senderName: (json['fromUserName'] as String?) ??
           (json['senderName'] as String?) ??
@@ -123,7 +133,7 @@ class ChatMessage {
       createdAt: parseDate(json['createdAt']) ?? DateTime.now(),
       updatedAt: parseDate(json['updatedAt']),
       isEdited: json['isEdited'] == true || json['edited'] == true,
-      replyToMessageId: (json['replyToMessageId'] as num?)?.toInt(),
+      replyToMessageId: _parseInt(json['replyToMessageId']),
       replyToContent: json['replyToContent'] as String?,
     );
   }

--- a/lib/resources/chat_api.dart
+++ b/lib/resources/chat_api.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+
+import 'package:booking_group_flutter/core/constants/api_constants.dart';
+import 'package:booking_group_flutter/models/chat_message.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// REST client for the chat module.
+class ChatApi {
+  Future<String> _requireToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    final token = prefs.getString('bearerToken');
+    if (token == null || token.isEmpty) {
+      throw Exception('Missing authentication token. Please sign in again.');
+    }
+    return token;
+  }
+
+  Map<String, dynamic> _decodeJsonBody(String body) {
+    if (body.isEmpty) return <String, dynamic>{};
+    return jsonDecode(body) as Map<String, dynamic>;
+  }
+
+  List<dynamic> _extractList(dynamic data) {
+    if (data is List) return data;
+    if (data is Map<String, dynamic>) {
+      final content = data['content'];
+      if (content is List) {
+        return content;
+      }
+    }
+    return const [];
+  }
+
+  String _extractMessage(String body, String fallback) {
+    try {
+      final json = _decodeJsonBody(body);
+      final message = json['message'];
+      if (message is String && message.isNotEmpty) {
+        return message;
+      }
+    } catch (_) {
+      // Ignore errors and fallback to provided message.
+    }
+    return fallback;
+  }
+
+  Future<List<ChatMessage>> getGroupMessages(
+    int groupId, {
+    int page = 1,
+    int size = 50,
+  }) async {
+    if (groupId <= 0) {
+      return const [];
+    }
+
+    final token = await _requireToken();
+    final response = await http.get(
+      Uri.parse(ApiConstants.getGroupChatMessagesUrl(groupId, page: page, size: size)),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode == 200) {
+      final json = _decodeJsonBody(response.body);
+      final list = _extractList(json['data']);
+      return list
+          .whereType<Map<String, dynamic>>()
+          .map(ChatMessage.fromJson)
+          .toList();
+    }
+
+    final message = _extractMessage(
+      response.body,
+      'Failed to load group messages (${response.statusCode}).',
+    );
+    throw Exception(message);
+  }
+
+  Future<ChatMessage> sendMessage({
+    required int groupId,
+    required String content,
+    int? replyToMessageId,
+  }) async {
+    if (groupId <= 0) {
+      throw Exception('Invalid group identifier.');
+    }
+
+    final token = await _requireToken();
+    final payload = <String, dynamic>{
+      'groupId': groupId,
+      'content': content,
+    };
+
+    if (replyToMessageId != null && replyToMessageId > 0) {
+      payload['replyToMessageId'] = replyToMessageId;
+    }
+
+    final response = await http.post(
+      Uri.parse(ApiConstants.createChatMessageUrl()),
+      headers: ApiConstants.authHeaders(token),
+      body: jsonEncode(payload),
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      final json = _decodeJsonBody(response.body);
+      final data = json['data'];
+      if (data is Map<String, dynamic>) {
+        return ChatMessage.fromJson(data);
+      }
+      if (data is List && data.isNotEmpty && data.first is Map<String, dynamic>) {
+        return ChatMessage.fromJson(data.first as Map<String, dynamic>);
+      }
+      return ChatMessage.fromJson(json);
+    }
+
+    final message = _extractMessage(
+      response.body,
+      'Failed to send message (${response.statusCode}).',
+    );
+    throw Exception(message);
+  }
+
+  Future<ChatMessage> updateMessage({
+    required int messageId,
+    required String content,
+  }) async {
+    if (messageId <= 0) {
+      throw Exception('Invalid message identifier.');
+    }
+
+    final token = await _requireToken();
+    final response = await http.put(
+      Uri.parse(ApiConstants.updateChatMessageUrl(messageId)),
+      headers: {
+        ...ApiConstants.authHeaders(token),
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+      body: content,
+    );
+
+    if (response.statusCode == 200) {
+      final json = _decodeJsonBody(response.body);
+      final data = json['data'];
+      if (data is Map<String, dynamic>) {
+        return ChatMessage.fromJson(data);
+      }
+      return ChatMessage.fromJson(json);
+    }
+
+    final message = _extractMessage(
+      response.body,
+      'Failed to update message (${response.statusCode}).',
+    );
+    throw Exception(message);
+  }
+
+  Future<void> deleteMessage(int messageId) async {
+    if (messageId <= 0) {
+      throw Exception('Invalid message identifier.');
+    }
+
+    final token = await _requireToken();
+    final response = await http.delete(
+      Uri.parse(ApiConstants.deleteChatMessageUrl(messageId)),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 204) {
+      return;
+    }
+
+    final message = _extractMessage(
+      response.body,
+      'Failed to delete message (${response.statusCode}).',
+    );
+    throw Exception(message);
+  }
+
+  Future<ChatMessage?> getMessageDetail(int messageId) async {
+    if (messageId <= 0) {
+      return null;
+    }
+
+    final token = await _requireToken();
+    final response = await http.get(
+      Uri.parse(ApiConstants.getChatMessageDetailUrl(messageId)),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode == 200) {
+      final json = _decodeJsonBody(response.body);
+      final data = json['data'];
+      if (data is Map<String, dynamic>) {
+        return ChatMessage.fromJson(data);
+      }
+      return ChatMessage.fromJson(json);
+    }
+
+    if (response.statusCode == 404) {
+      return null;
+    }
+
+    final message = _extractMessage(
+      response.body,
+      'Failed to load message detail (${response.statusCode}).',
+    );
+    throw Exception(message);
+  }
+
+  Future<List<ChatMessage>> searchMessages({
+    required int groupId,
+    required String keyword,
+    int page = 1,
+    int size = 50,
+  }) async {
+    if (groupId <= 0 || keyword.trim().length < 2) {
+      return const [];
+    }
+
+    final token = await _requireToken();
+    final response = await http.get(
+      Uri.parse(
+        ApiConstants.searchGroupChatMessagesUrl(
+          groupId,
+          keyword,
+          page: page,
+          size: size,
+        ),
+      ),
+      headers: ApiConstants.authHeaders(token),
+    );
+
+    if (response.statusCode == 200) {
+      final json = _decodeJsonBody(response.body);
+      final list = _extractList(json['data']);
+      return list
+          .whereType<Map<String, dynamic>>()
+          .map(ChatMessage.fromJson)
+          .toList();
+    }
+
+    final message = _extractMessage(
+      response.body,
+      'Failed to search messages (${response.statusCode}).',
+    );
+    throw Exception(message);
+  }
+}


### PR DESCRIPTION
## Summary
- add chat API constants, data models, and REST client for group messaging
- implement reusable chat controller and view with message actions and polling support
- expose a dedicated chat tab plus in-group popup access within the My Group detail page

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69072bed0f88832f9f4e8005d263a8a0